### PR TITLE
Add MediaButtonReceiver to support external media control

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+
     <queries>
         <intent>
             <action android:name="android.media.action.DISPLAY_AUDIO_EFFECT_CONTROL_PANEL" />
@@ -150,6 +151,14 @@
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </service>
+
+        <receiver
+            android:name="androidx.media3.session.MediaButtonReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MEDIA_BUTTON" />
+            </intent-filter>
+        </receiver>
 
         <meta-data
             android:name="com.google.android.gms.car.application"


### PR DESCRIPTION
This pull request adds the MediaButtonReceiver declaration in the AndroidManifest.xml to allow the app to respond to external media button events (e.g., Bluetooth headsets, Tasker, car controls, etc.).

This does not modify any other part of the app's logic, just enables compatibility with system-level playback controls.

Tested and working with Bluetooth headset and Tasker.

Español:
Este pull request añade la declaración de MediaButtonReceiver en el archivo AndroidManifest.xml para permitir que la app responda a eventos externos de botones multimedia (por ejemplo, auriculares Bluetooth, Tasker, controles del coche, etc.).

No se modifica ninguna otra parte de la lógica de la app; simplemente se habilita la compatibilidad con los controles de reproducción a nivel del sistema.

Probado y funcionando correctamente con auriculares Bluetooth y Tasker.