### PR TITLE
fix: enable scrolling and unify layout in PlayerMenu bottom sheet

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/BottomSheetMenu.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/BottomSheetMenu.kt
@@ -88,6 +88,7 @@ fun BottomSheetMenu(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 20.dp)
+                    .weight(1f, fill = false)
             ) {
                 state.content(this)
             }

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/menu/PlayerMenu.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
@@ -135,13 +136,14 @@ import kotlin.math.roundToInt
 import java.util.UUID
 
 @Composable
-fun PlayerMenu(
+fun ColumnScope.PlayerMenu(
     mediaMetadata: MediaMetadata?,
     navController: NavController,
     playerBottomSheetState: BottomSheetState,
     isQueueTrigger: Boolean? = false,
     onShowDetailsDialog: () -> Unit,
     onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     mediaMetadata ?: return
     val context = LocalContext.current
@@ -335,91 +337,11 @@ fun PlayerMenu(
             mediaMetadata.artists.joinToString(separator = " • ") { it.name }
         }
 
-    Surface(
-        shape = RoundedCornerShape(28.dp),
-        color = MaterialTheme.colorScheme.surfaceContainerLow,
-        modifier = Modifier.fillMaxWidth(),
-    ) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(14.dp),
-            modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
-        ) {
-            val thumb = mediaMetadata.thumbnailUrl
-            if (thumb.isNullOrBlank()) {
-                Box(
-                    modifier =
-                        Modifier
-                            .size(56.dp)
-                            .clip(RoundedCornerShape(16.dp))
-                            .background(MaterialTheme.colorScheme.surfaceContainerHighest),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.music_note),
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(22.dp),
-                    )
-                }
-            } else {
-                AsyncImage(
-                    model = thumb,
-                    contentDescription = null,
-                    contentScale = ContentScale.Crop,
-                    modifier =
-                        Modifier
-                            .size(56.dp)
-                            .clip(RoundedCornerShape(16.dp)),
-                )
-            }
-
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = stringResource(R.string.now_playing),
-                    style = MaterialTheme.typography.labelLarge,
-                    color = MaterialTheme.colorScheme.primary,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
-                    text = nowPlayingTitle,
-                    style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier.basicMarquee(),
-                )
-                if (nowPlayingSubtitle.isNotBlank()) {
-                    Text(
-                        text = nowPlayingSubtitle,
-                        style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.basicMarquee(),
-                    )
-                }
-            }
-        }
-    }
-
-    if (isQueueTrigger != true) {
-        Spacer(modifier = Modifier.height(12.dp))
-
-        PlayerVolumeCard(
-            volume = playerVolume.value,
-            onVolumeChange = { playerConnection.service.playerVolume.value = it },
-        )
-    }
-
-    Spacer(modifier = Modifier.height(16.dp))
-
     val configuration = LocalConfiguration.current
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 
     LazyColumn(
-        userScrollEnabled = !isPortrait,
+        modifier = modifier.weight(1f).fillMaxWidth(),
         contentPadding = PaddingValues(
             start = 0.dp,
             top = 0.dp,
@@ -427,6 +349,92 @@ fun PlayerMenu(
             bottom = 8.dp + WindowInsets.systemBars.asPaddingValues().calculateBottomPadding(),
         ),
     ) {
+        item {
+            Surface(
+                shape = RoundedCornerShape(28.dp),
+                color = MaterialTheme.colorScheme.surfaceContainerLow,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(14.dp),
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 12.dp),
+                ) {
+                    val thumb = mediaMetadata.thumbnailUrl
+                    if (thumb.isNullOrBlank()) {
+                        Box(
+                            modifier =
+                                Modifier
+                                    .size(56.dp)
+                                    .clip(RoundedCornerShape(16.dp))
+                                    .background(MaterialTheme.colorScheme.surfaceContainerHighest),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.music_note),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier.size(22.dp),
+                            )
+                        }
+                    } else {
+                        AsyncImage(
+                            model = thumb,
+                            contentDescription = null,
+                            contentScale = ContentScale.Crop,
+                            modifier =
+                                Modifier
+                                    .size(56.dp)
+                                    .clip(RoundedCornerShape(16.dp)),
+                        )
+                    }
+
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(R.string.now_playing),
+                            style = MaterialTheme.typography.labelLarge,
+                            color = MaterialTheme.colorScheme.primary,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = nowPlayingTitle,
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.basicMarquee(),
+                        )
+                        if (nowPlayingSubtitle.isNotBlank()) {
+                            Text(
+                                text = nowPlayingSubtitle,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.basicMarquee(),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        if (isQueueTrigger != true) {
+            item {
+                Spacer(modifier = Modifier.height(12.dp))
+
+                PlayerVolumeCard(
+                    volume = playerVolume.value,
+                    onVolumeChange = { playerConnection.service.playerVolume.value = it },
+                )
+            }
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
         item {
             NewActionGrid(
                 actions = listOf(
@@ -1081,14 +1089,14 @@ fun TempoPitchDialog(onDismiss: () -> Unit) {
 
                     Text(
                         text =
-                        when (pitchMode) {
-                            PitchMode.Semitones -> {
-                                val semitones = pitchToSemitones(pitch)
-                                "${if (semitones > 0) "+" else ""}$semitones"
-                            }
+                            when (pitchMode) {
+                                PitchMode.Semitones -> {
+                                    val semitones = pitchToSemitones(pitch)
+                                    "${if (semitones > 0) "+" else ""}$semitones"
+                                }
 
-                            PitchMode.Multiplier -> "x${formatMultiplier(pitch)}"
-                        },
+                                PitchMode.Multiplier -> "x${formatMultiplier(pitch)}"
+                            },
                         style = MaterialTheme.typography.titleMedium,
                         textAlign = TextAlign.End,
                     )


### PR DESCRIPTION
Closes #587

## Solution
- Removed hardcoded scroll restriction in portrait mode.
- Moved Now Playing and Volume header components into the LazyColumn to prevent layout blocking.
- Converted PlayerMenu to `ColumnScope` extension to use weighted modifiers.
- Updated BottomSheetMenu to support weighted child expansion for better scrolling in landscape.
- Fixed the Player Menu bottom sheet scrolling issue so hidden options like **Equalizer** and **Tempo** are now accessible on smaller screens and constrained layouts.

### Status -



https://github.com/user-attachments/assets/0dda51e5-9a39-4e15-beb3-aeaa14400746


