### PR TITLE
Gate setWebContentsDebuggingEnabled on BuildConfig.DEBUG in DiscordLoginScreen

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/DiscordLoginScreen.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/DiscordLoginScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import com.arturo254.opentune.BuildConfig
 import com.arturo254.opentune.R
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -67,7 +68,9 @@ fun DiscordLoginScreen(navController: NavController) {
                     ViewGroup.LayoutParams.MATCH_PARENT
                 )
 
-                WebView.setWebContentsDebuggingEnabled(true)
+                if (BuildConfig.DEBUG) {
+                    WebView.setWebContentsDebuggingEnabled(true)
+                }
 
                 settings.javaScriptEnabled = true
                 settings.domStorageEnabled = true


### PR DESCRIPTION
Closes #596.

`DiscordLoginScreen` builds the Discord OAuth WebView and called `WebView.setWebContentsDebuggingEnabled(true)` unconditionally inside the factory. Since this is a process-wide static, a release build leaves every WebView the app spawns inspectable from `chrome://inspect`, including this WebView and the `Android` JS bridge that handles the token hand-off (CWE-489).

### Change

Wrap the call in `if (BuildConfig.DEBUG)`. `AboutScreen` already imports `BuildConfig` from `com.arturo254.opentune` and uses the same pattern for debug-only logic, so the import is consistent.

Debug builds keep the inspector available. Release builds no longer expose it.