### PR TITLE
Use evaluateJavascript in LoginScreen onPageFinished

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/LoginScreen.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/LoginScreen.kt
@@ -87,9 +87,9 @@ fun LoginScreen(
                     override fun onPageFinished(view: WebView, url: String?) {
                         val isYouTubePage = url?.contains("youtube.com", ignoreCase = true) == true
                         if (isYouTubePage) {
-                            loadUrl("javascript:Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)")
-                            loadUrl("javascript:Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)")
-                            loadUrl("javascript:void((function(){try{var c=window.ytcfg;if(c&&c.get){var t=c.get('PO_TOKEN');if(t){Android.onRetrievePoToken(t);return}}var s=document.querySelectorAll('script');for(var i=0;i<s.length;i++){var m=s[i].textContent.match(/\"PO_TOKEN\":\"([^\"]+)\"/);if(m){Android.onRetrievePoToken(m[1]);return}}}catch(e){}})())")
+                            view.evaluateJavascript("Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)", null)
+                            view.evaluateJavascript("Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)", null)
+                            view.evaluateJavascript("(function(){try{var c=window.ytcfg;if(c&&c.get){var t=c.get('PO_TOKEN');if(t){Android.onRetrievePoToken(t);return}}var s=document.querySelectorAll('script');for(var i=0;i<s.length;i++){var m=s[i].textContent.match(/\"PO_TOKEN\":\"([^\"]+)\"/);if(m){Android.onRetrievePoToken(m[1]);return}}}catch(e){}})()", null)
                         }
 
                         val mergedCookie = mergeYouTubeCookies(cookieManager)


### PR DESCRIPTION
Closes #607.

`LoginScreen.kt` injects three JS snippets in `onPageFinished` using the legacy `loadUrl("javascript:...")` form. Each one is treated by WebView as a navigation, pushes a `javascript:` entry into the history, and has no way to surface errors back to Kotlin.

This switches them to `view.evaluateJavascript(script, null)`, which is the form the platform docs recommend on API 19 plus. The `Android` bridge methods (`onRetrieveVisitorData`, `onRetrieveDataSyncId`, `onRetrievePoToken`) keep firing because the scripts still run in the page context where the bridge is registered.

```diff
                         if (isYouTubePage) {
-                            loadUrl("javascript:Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)")
-                            loadUrl("javascript:Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)")
-                            loadUrl("javascript:void((function(){ ... })())")
+                            view.evaluateJavascript("Android.onRetrieveVisitorData(window.yt.config_.VISITOR_DATA)", null)
+                            view.evaluateJavascript("Android.onRetrieveDataSyncId(window.yt.config_.DATASYNC_ID)", null)
+                            view.evaluateJavascript("(function(){ ... })()", null)
                         }
```

No other behavior changes. The cookie merge / login completion path below the injections is untouched.