### PR TITLE
feat: Add debug APK CI/CD workflow with GitHub Actions

### DIFF
--- a/.github/workflows/pr-debug-build.yml
+++ b/.github/workflows/pr-debug-build.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Build debug APK
         run: |
           set -e
-          ./gradlew assembleDebug --no-daemon --stacktrace
+          ./gradlew assembleUniversalDebug --no-daemon --stacktrace
 
       # Rename APK for clarity
       - name: Rename APK artifact

--- a/.github/workflows/pr-debug-build.yml
+++ b/.github/workflows/pr-debug-build.yml
@@ -1,0 +1,179 @@
+# ───────────────────
+# Pull Request — Debug APK Build & Comment
+# Triggered on every pull request targeting any branch.
+# Cancels any in-progress run for the same PR when a new commit is pushed,
+# so only the latest commit's build result ever posts to the PR.
+# ───────────────────
+
+name: PR Debug Build test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: ["**"]
+    paths-ignore:
+      - "assets/**"
+      - "docs/**"
+      - "fastlane/**"
+      - "**/*.md"
+      - "LICENSE"
+
+# One concurrent run per PR. New pushes cancel the previous run.
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  build:
+    name: Android Debug Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      # Checkout repo
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+      # Java setup
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: "21"
+          distribution: "temurin"
+          cache: gradle
+
+      # Gradle permissions
+      - name: Grant execute permission to gradlew
+        run: chmod +x ./gradlew
+
+      # Extract version from build.gradle.kts
+      - name: Extract app version from build.gradle.kts
+        id: version
+        run: |
+          # Extract versionName and versionCode from app/build.gradle.kts
+          VERSION=$(grep 'versionName = ' app/build.gradle.kts | grep -oP '"[^"]+"' | head -1 | tr -d '"')
+          VERSION_CODE=$(grep 'versionCode = ' app/build.gradle.kts | grep -oP '[0-9]+' | head -1)
+          
+          # Parse major.minor.patch
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
+          
+          cat <<EOFOUT >> "$GITHUB_OUTPUT"
+          version=$VERSION
+          version_code=$VERSION_CODE
+          version_major=${MAJOR:-0}
+          version_minor=${MINOR:-0}
+          version_patch=${PATCH:-0}
+          EOFOUT
+
+      # Build Debug APK
+      - name: Build debug APK
+        run: |
+          set -e
+          ./gradlew assembleDebug --no-daemon --stacktrace
+
+      # Rename APK for clarity
+      - name: Rename APK artifact
+        run: |
+          mkdir -p artifacts
+          APK_PATH=$(find app/build/outputs -type f -name "app-universal-debug.apk" | head -n 1)
+          if [ -z "$APK_PATH" ] || [ ! -f "$APK_PATH" ]; then
+            echo "Error: app-universal-debug.apk not found"
+            exit 1
+          fi
+          echo "Found APK: $APK_PATH"
+          cp "$APK_PATH" "artifacts/OpenTune-v${{ steps.version.outputs.version }}-debug.apk"
+
+      # Upload artifact
+      - name: Upload debug APK
+        id: upload
+        uses: actions/upload-artifact@v7
+        with:
+          name: OpenTune-v${{ steps.version.outputs.version }}-debug-PR${{ github.event.pull_request.number }}
+          path: artifacts/OpenTune-v${{ steps.version.outputs.version }}-debug.apk
+          retention-days: 60
+
+      # Delete old bot comment if exists
+      - name: Delete old APK comment on PR
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const repo     = context.repo;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              ...repo,
+              issue_number: prNumber,
+            });
+
+            const botComment = comments.find(c =>
+              c.body.includes('<!-- pr-debug-apk-comment -->')
+            );
+
+            if (botComment) {
+              await github.rest.issues.deleteComment({
+                ...repo,
+                comment_id: botComment.id,
+              });
+              console.log(`Deleted old bot comment: ${botComment.id}`);
+            } else {
+              console.log('No previous bot comment found, skipping delete.');
+            }
+
+      # Post new comment on PR
+      - name: Post APK download comment on PR
+        uses: actions/github-script@v9
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          RUN_NUMBER: ${{ github.run_number }}
+          ARTIFACT_ID: ${{ steps.upload.outputs.artifact-id }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber   = context.payload.pull_request.number;
+            const version    = process.env.VERSION;
+            const runNumber  = process.env.RUN_NUMBER;
+            const runId      = context.runId;
+            const repo       = context.repo;
+            const artifactId = process.env.ARTIFACT_ID;
+            const artifactName = `OpenTune-v${version}-debug-PR${prNumber}`;
+            const downloadVersion = `${version}+${runNumber}`;
+
+            const runUrl      = `https://github.com/${repo.owner}/${repo.repo}/actions/runs/${runId}`;
+            const artifactUrl = `https://github.com/${repo.owner}/${repo.repo}/actions/runs/${runId}/artifacts/${artifactId}`;
+
+            const badgeUrl   = `https://img.shields.io/badge/Download%20APK-v${downloadVersion}-4CAF50?style=for-the-badge&logo=android&logoColor=white`;
+            const commentBody = `<!-- pr-debug-apk-comment -->
+            ## ✅ Debug APK Build Successful
+
+            [![Static Badge](https://img.shields.io/badge/debug_build-passing-brightgreen?style=for-the-badge&logo=android)](${runUrl})
+            
+            | Detail | Value |
+            |--------|-------|
+            | **Version** | \`v${version}\` |
+            | **Build Num** | \`#${runNumber}\` |
+            | **PR** | #${prNumber} |
+            | **Artifact** | \`${artifactName}\` |
+            | **Expires** | 60 days |
+
+            ---
+
+            ### 📲 Download
+
+            [![Download APK v${downloadVersion}](${badgeUrl})](${artifactUrl})
+
+            ---
+            <sub>🤖 This comment is auto-generated by the PR Debug APK build workflow.</sub>`;
+
+            await github.rest.issues.createComment({
+              ...repo,
+              issue_number: prNumber,
+              body: commentBody,
+            });

--- a/.github/workflows/pr-debug-build.yml
+++ b/.github/workflows/pr-debug-build.yml
@@ -149,11 +149,12 @@ jobs:
             const runUrl      = `https://github.com/${repo.owner}/${repo.repo}/actions/runs/${runId}`;
             const artifactUrl = `https://github.com/${repo.owner}/${repo.repo}/actions/runs/${runId}/artifacts/${artifactId}`;
 
-            const badgeUrl   = `https://img.shields.io/badge/Download%20APK-v${downloadVersion}-4CAF50?style=for-the-badge&logo=android&logoColor=white`;
+            const buildPassUrl   = `https://img.shields.io/badge/debug_build-passing-brightgreen?style=for-the-badge&logo=android`;
+            const badgeUrl    = `https://img.shields.io/badge/Download%20APK-v${downloadVersion}-4CAF50?style=for-the-badge&logo=android&logoColor=white`;
             const commentBody = `<!-- pr-debug-apk-comment -->
             ## ✅ Debug APK Build Successful
 
-            [![Static Badge](https://img.shields.io/badge/debug_build-passing-brightgreen?style=for-the-badge&logo=android)](${runUrl})
+            [![Debug APK Build passing](${buildPassUrl})](${runUrl})
             
             | Detail | Value |
             |--------|-------|

--- a/.github/workflows/pr-debug-build.yml
+++ b/.github/workflows/pr-debug-build.yml
@@ -5,7 +5,7 @@
 # so only the latest commit's build result ever posts to the PR.
 # ───────────────────
 
-name: PR Debug Build test
+name: Debug Build
 
 on:
   pull_request:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,6 +15,8 @@ if (localPropertiesFile.exists()) {
     localProperties.load(localPropertiesFile.inputStream())
 }
 
+val vBuild = System.getenv("GITHUB_RUN_NUMBER")?.toIntOrNull() ?: 0
+
 android {
     namespace = "com.arturo254.opentune"
     compileSdk = 36
@@ -98,6 +100,7 @@ android {
         }
         debug {
             applicationIdSuffix = ".debug"
+            versionNameSuffix = ".$vBuild-debug"
             isDebuggable = true
         }
     }


### PR DESCRIPTION
## Overview
Adds automated debug APK building and posting to GitHub Actions with PR comments for easier testing and QA verification.

## Changes
- **build.gradle.kts**: 
  - Added `versionNameSuffix = ".$vBuild-debug"` to debug build variant
  - Dynamically appends GitHub run number to APK version for unique identification
  - Makes debug builds easily distinguishable from release builds

- **pr-debug-build.yml** (New GitHub Actions Workflow):
  - Triggers on every PR (opened, synchronize, reopened)
  - Runs only on relevant code changes (ignores docs, assets, markdown)
  - Single concurrent run per PR with auto-cancel on new pushes
  - Extracts versionName and versionCode from build.gradle.kts
  - Builds universal debug APK with full stacktrace for troubleshooting
  - Uploads APK as artifact with 60-day retention
  - Auto-posts PR comment with:
    - Build status badge
    - Version info and build number
    - Direct download link to APK artifact
  - Cleans up old bot comments to keep PR thread clean

## Benefits
✅ Quick testing without local builds
✅ Version tracking with run numbers (v1.0.0+123)
✅ Automatic cleanup of stale comments
✅ Single concurrent build per PR (saves CI minutes)
✅ Skip build on doc-only changes (docs, markdown, assets)

## ⚠️ Required Permissions

For the workflow to post and delete comments on PRs, enable GitHub Actions permissions:

1. Go to **[Settings → Actions](https://github.com/Arturo254/OpenTune/settings/actions)**
2. Under **"Workflow permissions"**, enable:
   - ✅ **Allow GitHub Actions to create and approve pull requests**

**Screenshot:**


![Workflow Permissions](https://github.com/user-attachments/assets/848693a3-478d-4a88-8238-453469819dfc)



Without these permissions, the workflow will fail when trying to post/delete PR comments.