### PR TITLE
fix: replace leftover GPL placeholder text in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -652,7 +652,7 @@ Also add information on how to contact you by electronic and paper mail.
   If the program does terminal interaction, make it output a short
 notice like this when it starts in an interactive mode:
 
-    <program>  Copyright (C) <year>  <name of author>
+    OpenTune  Copyright (C) 2025  Arturo Cervantes
     This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
     This is free software, and you are welcome to redistribute it
     under certain conditions; type `show c' for details.


### PR DESCRIPTION
Summary

Replaces the leftover GPL template placeholder text in the "LICENSE" file with proper project copyright information.

Changes

```diff
-    <program>  Copyright (C) <year>  <name of author>
+    OpenTune Copyright (C) 2025 Arturo Cervantes
```

Related

Closes #621