### PR TITLE
feat(ui): implement retry logic for contributors list in About screen

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/AboutScreen.kt
@@ -227,7 +227,7 @@ fun AboutScreen(
                 item {
                     ErrorCard(
                         message = error ?: "Unknown error",
-                        onRetry = { /* TODO: implement retry */ }
+                        onRetry = { viewModel.fetchContributorsFromGitHub() }
                     )
                 }
             } else if (contributors.isNotEmpty()) {
@@ -685,6 +685,14 @@ private fun ErrorCard(
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
+
+            FilledTonalButton(
+                onClick = onRetry,
+                shape = RoundedCornerShape(14.dp),
+                modifier = Modifier.padding(top = 4.dp)
+            ) {
+                Text(text = stringResource(R.string.retry))
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/arturo254/opentune/viewmodels/AboutViewModel.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/viewmodels/AboutViewModel.kt
@@ -40,7 +40,7 @@ class AboutViewModel : ViewModel() {
         fetchContributorsFromGitHub()
     }
 
-    private fun fetchContributorsFromGitHub() {
+    fun fetchContributorsFromGitHub() {
         viewModelScope.launch {
             _isLoading.value = true
             _error.value = null


### PR DESCRIPTION
This PR implements a retry mechanism for the contributors list in the About screen. 

Key changes:
1. Modified AboutViewModel to make the data fetching method fetchContributorsFromGitHub() public.
2. Enhanced the ErrorCard component in AboutScreen with a 'Retry' button that triggers the data fetch.
3. Updated the UI to handle the retry callback.

Technically, this uses the existing AboutViewModel state management and consistent Material 3 styling with FilledTonalButton and RoundedCornerShape(14.dp) as seen elsewhere in the screen.


<!-- - Made fetchContributorsFromGitHub() in AboutViewModel public to allow manual refresh.
- Updated ErrorCard in AboutScreen to include a "Retry" button.
- Connected the "Retry" button to the ViewModel's fetch method.
- Used consistent styling with existing UI components (FilledTonalButton with 14dp rounded corners). -->