### PR TITLE
Add docstring to Keyword data class

### DIFF
--- a/kugou/src/main/kotlin/com/arturo254/opentune/kugou/models/Keyword.kt
+++ b/kugou/src/main/kotlin/com/arturo254/opentune/kugou/models/Keyword.kt
@@ -8,4 +8,7 @@
 
 package com.arturo254.opentune.kugou.models
 
+/**
+ * 表示关键词的数据类，包含标题和艺术家信息。
+ */
 data class Keyword(val title: String, val artist: String)


### PR DESCRIPTION
## Problem
The `Keyword` data class in the `kugou` module is a public component but lacks documentation, which negatively impacts code readability and maintainability. Clear documentation is essential for developers to understand the purpose and structure of this class.

## Changes
- Added a Kotlin docstring to the `Keyword` class, describing its role as a data class that holds keyword information including title and artist fields.
- The documentation follows Kotlin conventions and does not alter any existing code structure or functionality.

## Verification
- Review the added docstring to ensure it accurately reflects the class's purpose and fields.
- Since this is a documentation-only change, no functional tests are required; however, existing tests can be run to confirm no regressions were introduced. The change is minimal and backward-compatible.