### PR TITLE
fix(db): make related-song queries deterministic

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/db/DatabaseDao.kt
@@ -359,29 +359,29 @@ interface DatabaseDao {
     @Query(
         """
         SELECT song.*
-        FROM (SELECT *, COUNT(1) AS referredCount
+        FROM (SELECT relatedSongId, COUNT(1) AS referredCount
               FROM related_song_map
+              WHERE songId IN (SELECT songId
+                               FROM (SELECT songId
+                                     FROM event
+                                     ORDER BY ROWID DESC
+                                     LIMIT 5)
+                               UNION
+                               SELECT songId
+                               FROM (SELECT songId
+                                     FROM event
+                                     WHERE timestamp > :now - 86400000 * 7
+                                     GROUP BY songId
+                                     ORDER BY SUM(playTime) DESC
+                                     LIMIT 5)
+                               UNION
+                               SELECT id
+                               FROM (SELECT id
+                                     FROM song
+                                     ORDER BY totalPlayTime DESC
+                                     LIMIT 10))
               GROUP BY relatedSongId) map
                  JOIN song ON song.id = map.relatedSongId
-        WHERE songId IN (SELECT songId
-                         FROM (SELECT songId
-                               FROM event
-                               ORDER BY ROWID DESC
-                               LIMIT 5)
-                         UNION
-                         SELECT songId
-                         FROM (SELECT songId
-                               FROM event
-                               WHERE timestamp > :now - 86400000 * 7
-                               GROUP BY songId
-                               ORDER BY SUM(playTime) DESC
-                               LIMIT 5)
-                         UNION
-                         SELECT id
-                         FROM (SELECT id
-                               FROM song
-                               ORDER BY totalPlayTime DESC
-                               LIMIT 10))
         ORDER BY referredCount DESC
         LIMIT 100
     """,
@@ -1197,7 +1197,7 @@ interface DatabaseDao {
 
     @Transaction
     @Query(
-        "SELECT song.* FROM (SELECT * from related_song_map GROUP BY relatedSongId) map JOIN song ON song.id = map.relatedSongId where songId = :songId",
+        "SELECT song.* FROM (SELECT relatedSongId FROM related_song_map WHERE songId = :songId GROUP BY relatedSongId) map JOIN song ON song.id = map.relatedSongId",
     )
     fun getRelatedSongs(songId: String): Flow<List<Song>>
 
@@ -1205,13 +1205,13 @@ interface DatabaseDao {
     @Query(
         """
         SELECT song.*
-        FROM (SELECT *
+        FROM (SELECT relatedSongId
               FROM related_song_map
+              WHERE songId = :songId
               GROUP BY relatedSongId) map
                  JOIN
              song
              ON song.id = map.relatedSongId
-        WHERE songId = :songId
         """
     )
     fun relatedSongs(songId: String): List<Song>


### PR DESCRIPTION
### Purpose
The home "Quick Picks" section (and related-song lookups) intermittently
shows, disappears, then reappears across app launches - even with a full
play history and a stable network connection. This PR makes the underlying
queries deterministic so the content stops flickering in and out.

### Motivation
Three queries in `DatabaseDao.kt` build recommendations from `related_song_map`
(a `songId -> relatedSongId` mapping). Each one runs:

```sql
FROM (SELECT *, ... FROM related_song_map GROUP BY relatedSongId) map
JOIN song ON song.id = map.relatedSongId
WHERE songId IN ( ...seed songs... )
```

The GROUP BY relatedSongId is applied before the WHERE songId IN (...)
filter. After the grouping, songId is a bare (non-aggregated) column, so
SQLite keeps an arbitrary value per group. Which value survives depends on
row insertion order in related_song_map, which changes every time a song is
streamed (new related rows are cached). The seed filter then matches that
arbitrary songId non-deterministically:

- when the surviving songId happens to be a seed -> the related song appears
- when it is some other source song -> the related song is dropped

When enough rows drop at once, the entire Quick Picks section becomes empty,
and pull-to-refresh can't recover it (it re-runs the same query against the
same data). This is the observed "shows / vanishes / comes back" instability.

### Changes

Move the WHERE songId ... filter inside the subquery, before GROUP BY,
so the songId -> relatedSongId links are intact when filtering. Affects all
three queries that share this pattern:

- quickPicks() - home Quick Picks
- getRelatedSongs() - LAST_LISTEN Quick Picks mode
- relatedSongs() - related-song lookups

As a side benefit, referredCount in quickPicks() now counts how many of
the user's seeds referred each related song (the intended ranking signal),
instead of counting all rows including non-seeds.

No schema change, no migration, public DAO signatures unchanged.

### Verification

- ./gradlew :app:compileUniversalDebugKotlin succeeds - Room validates every
@Query against the schema at compile time (KSP), so the rewritten SQL is
confirmed syntactically valid with all columns resolving.
- No existing DAO/Room tests to extend; the compile-time validator is the
authoritative check for @Query correctness in this module.