### PR TITLE
feat: add Liquid Glass blur effect to Navigation Bar and MiniPlayer

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/MainActivity.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/MainActivity.kt
@@ -179,6 +179,7 @@ import com.arturo254.opentune.constants.FloatingToolbarHeight
 import com.arturo254.opentune.constants.FloatingToolbarHorizontalPadding
 import com.arturo254.opentune.constants.HasPressedStarKey
 import com.arturo254.opentune.constants.LaunchCountKey
+import com.arturo254.opentune.constants.EnableLiquidGlassKey
 import com.arturo254.opentune.constants.LiquidGlassNavBarKey
 import com.arturo254.opentune.constants.LyricsSyncOffsetKey
 import com.arturo254.opentune.constants.MiniPlayerBottomSpacing
@@ -233,6 +234,9 @@ import com.arturo254.opentune.ui.component.BottomSheetPageState
 import com.arturo254.opentune.ui.component.MenuState
 import com.arturo254.opentune.ui.component.TopSearch
 import com.arturo254.opentune.ui.component.rememberBottomSheetState
+import com.arturo254.opentune.ui.component.LocalBackdrop
+import com.arturo254.opentune.ui.component.layerBackdrop
+import com.arturo254.opentune.ui.component.rememberBackdrop
 import com.arturo254.opentune.ui.component.shimmer.ShimmerTheme
 import com.arturo254.opentune.ui.menu.YouTubeSongMenu
 import com.arturo254.opentune.ui.player.BottomSheetPlayer
@@ -578,16 +582,24 @@ class MainActivity : ComponentActivity() {
             val darkTheme by rememberEnumPreference(DarkModeKey, defaultValue = DarkMode.AUTO)
             val useSystemFont by rememberPreference(UseSystemFontKey, defaultValue = false)
             val lyricsSyncOffset by rememberPreference(LyricsSyncOffsetKey, defaultValue = 0)
+            val enableLiquidGlass by rememberPreference(EnableLiquidGlassKey, defaultValue = false)
+            val backdrop = rememberBackdrop()
             val isSystemInDarkTheme = isSystemInDarkTheme()
             val useDarkTheme =
-                remember(darkTheme, isSystemInDarkTheme) {
-                    if (darkTheme == DarkMode.AUTO) isSystemInDarkTheme else darkTheme == DarkMode.ON
+                remember(darkTheme, isSystemInDarkTheme, enableLiquidGlass) {
+                    if (enableLiquidGlass) {
+                        true
+                    } else if (darkTheme == DarkMode.AUTO) {
+                        isSystemInDarkTheme
+                    } else {
+                        darkTheme == DarkMode.ON
+                    }
                 }
             LaunchedEffect(useDarkTheme) {
                 setSystemBarAppearance(useDarkTheme)
             }
             val pureBlackEnabled by rememberPreference(PureBlackKey, defaultValue = false)
-            val pureBlack = pureBlackEnabled && useDarkTheme
+            val pureBlack = pureBlackEnabled && useDarkTheme && !enableLiquidGlass
 
             val customThemeSeedPalette = remember(customThemeColorValue) {
                 if (customThemeColorValue.startsWith("#")) {
@@ -1158,6 +1170,7 @@ class MainActivity : ComponentActivity() {
                         LocalSyncUtils provides syncUtils,
                         LocalBottomSheetPageState provides bottomSheetPageState,
                         LocalMenuState provides menuState,
+                        LocalBackdrop provides backdrop,
                     ) {
                         Row {
                             AnimatedVisibility(useRail && shouldShowNavigationBar) {
@@ -1739,6 +1752,11 @@ class MainActivity : ComponentActivity() {
                                     .fillMaxSize()
                                     .nestedScroll(searchBarScrollBehavior.nestedScrollConnection)
                             ) {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .let { if (enableLiquidGlass) it.layerBackdrop(backdrop) else it }
+                                ) {
                                 var transitionDirection =
                                     AnimatedContentTransitionScope.SlideDirection.Left
 
@@ -1866,6 +1884,7 @@ class MainActivity : ComponentActivity() {
                                     )
                                 }
                             }
+                        }
                         }
 
                         BottomSheetMenu(

--- a/app/src/main/kotlin/com/arturo254/opentune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/constants/PreferenceKeys.kt
@@ -43,6 +43,7 @@ val BlurRadiusKey = floatPreferencesKey("blurRadius")
 val MiniPlayerLastAnchorKey = intPreferencesKey("miniPlayerLastAnchor")
 val EnableHapticFeedbackKey = booleanPreferencesKey("enableHapticFeedback")
 val PlayerFullscreenKey = booleanPreferencesKey("player_fullscreen")
+val EnableLiquidGlassKey = booleanPreferencesKey("enableLiquidGlass")
 
 val ProviderOrderKey = stringPreferencesKey("lyrics_provider_order")
 

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/FloatingNavigationToolbar.kt
@@ -108,21 +108,10 @@ fun FloatingNavigationToolbar(
     val hasOverflowAction = onShuffleClick != null && shuffleIconRes != null
     val hasFabAction = onFabClick != null && fabIconRes != null
 
-    val layer = rememberGraphicsLayer()
-    val luminanceAnimation = remember { Animatable(0.3f) }
-    val backdrop = LocalBackdrop.current
-
     val toolbarModifier = Modifier
         .widthIn(max = 480.dp)
         .let {
-            if (enableLiquidGlass && backdrop != null) {
-                it.drawBackdropCustomShape(
-                    backdrop = backdrop,
-                    layer = layer,
-                    luminanceAnimation = luminanceAnimation.value,
-                    shape = CircleShape
-                )
-            } else it
+            if (enableLiquidGlass) it.graphicsLayer { shadowElevation = 0f } else it
         }
 
     BoxWithConstraints(
@@ -187,14 +176,7 @@ fun FloatingNavigationToolbar(
                 modifier = Modifier
                     .widthIn(max = 420.dp)
                     .let {
-                        if (enableLiquidGlass && backdrop != null) {
-                            it.drawBackdropCustomShape(
-                                backdrop = backdrop,
-                                layer = layer,
-                                luminanceAnimation = luminanceAnimation.value,
-                                shape = CircleShape
-                            )
-                        } else it
+                        if (enableLiquidGlass) it.graphicsLayer { shadowElevation = 0f } else it
                     },
                 colors = toolbarColors,
                 scrollBehavior = scrollBehavior,
@@ -245,7 +227,27 @@ private fun ToolbarItemsContainer(
         label = "pillOffset"
     )
 
-    Box(modifier = Modifier.height(IntrinsicSize.Min)) {
+    val enableLiquidGlass by rememberPreference(EnableLiquidGlassKey, defaultValue = false)
+    val layer = rememberGraphicsLayer()
+    val luminanceAnimation = remember { Animatable(0.3f) }
+    val backdrop = LocalBackdrop.current
+
+    Box(
+        modifier = Modifier
+            .let {
+                if (enableLiquidGlass && backdrop != null) {
+                    it
+                        .drawBackdropCustomShape(
+                            backdrop = backdrop,
+                            layer = layer,
+                            luminanceAnimation = luminanceAnimation.value,
+                            shape = CircleShape
+                        )
+                        .padding(horizontal = 8.dp, vertical = 4.dp)
+                } else it
+            }
+            .height(IntrinsicSize.Min)
+    ) {
         if (targetWidth > 0.dp) {
             Box(
                 modifier = Modifier

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/FloatingNavigationToolbar.kt
@@ -108,10 +108,21 @@ fun FloatingNavigationToolbar(
     val hasOverflowAction = onShuffleClick != null && shuffleIconRes != null
     val hasFabAction = onFabClick != null && fabIconRes != null
 
+    val layer = rememberGraphicsLayer()
+    val luminanceAnimation = remember { Animatable(0.3f) }
+    val backdrop = LocalBackdrop.current
+
     val toolbarModifier = Modifier
         .widthIn(max = 480.dp)
         .let {
-            if (enableLiquidGlass) it.graphicsLayer { shadowElevation = 0f } else it
+            if (enableLiquidGlass && backdrop != null) {
+                it.drawBackdropCustomShape(
+                    backdrop = backdrop,
+                    layer = layer,
+                    luminanceAnimation = luminanceAnimation.value,
+                    shape = CircleShape
+                )
+            } else it
         }
 
     BoxWithConstraints(
@@ -176,7 +187,14 @@ fun FloatingNavigationToolbar(
                 modifier = Modifier
                     .widthIn(max = 420.dp)
                     .let {
-                        if (enableLiquidGlass) it.graphicsLayer { shadowElevation = 0f } else it
+                        if (enableLiquidGlass && backdrop != null) {
+                            it.drawBackdropCustomShape(
+                                backdrop = backdrop,
+                                layer = layer,
+                                luminanceAnimation = luminanceAnimation.value,
+                                shape = CircleShape
+                            )
+                        } else it
                     },
                 colors = toolbarColors,
                 scrollBehavior = scrollBehavior,
@@ -227,27 +245,7 @@ private fun ToolbarItemsContainer(
         label = "pillOffset"
     )
 
-    val enableLiquidGlass by rememberPreference(EnableLiquidGlassKey, defaultValue = false)
-    val layer = rememberGraphicsLayer()
-    val luminanceAnimation = remember { Animatable(0.3f) }
-    val backdrop = LocalBackdrop.current
-
-    Box(
-        modifier = Modifier
-            .let {
-                if (enableLiquidGlass && backdrop != null) {
-                    it
-                        .drawBackdropCustomShape(
-                            backdrop = backdrop,
-                            layer = layer,
-                            luminanceAnimation = luminanceAnimation.value,
-                            shape = CircleShape
-                        )
-                        .padding(horizontal = 16.dp, vertical = 8.dp)
-                } else it
-            }
-            .height(IntrinsicSize.Min)
-    ) {
+    Box(modifier = Modifier.height(IntrinsicSize.Min)) {
         if (targetWidth > 0.dp) {
             Box(
                 modifier = Modifier

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/FloatingNavigationToolbar.kt
@@ -78,6 +78,7 @@ import androidx.compose.ui.unit.dp
 import com.arturo254.opentune.R
 import com.arturo254.opentune.ui.screens.Screens
 import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.animation.core.Animatable
 import com.arturo254.opentune.constants.EnableLiquidGlassKey
 import com.arturo254.opentune.utils.rememberPreference
@@ -107,6 +108,12 @@ fun FloatingNavigationToolbar(
     val hasOverflowAction = onShuffleClick != null && shuffleIconRes != null
     val hasFabAction = onFabClick != null && fabIconRes != null
 
+    val toolbarModifier = Modifier
+        .widthIn(max = 480.dp)
+        .let {
+            if (enableLiquidGlass) it.graphicsLayer { shadowElevation = 0f } else it
+        }
+
     BoxWithConstraints(
         modifier = modifier.fillMaxWidth(),
         contentAlignment = Alignment.Center,
@@ -126,7 +133,7 @@ fun FloatingNavigationToolbar(
                         musicRecognitionContentDescription = musicRecognitionContentDescription,
                     )
                 },
-                modifier = Modifier.widthIn(max = 480.dp),
+                modifier = toolbarModifier,
                 colors = toolbarColors,
                 scrollBehavior = scrollBehavior,
                 animationSpec = FloatingToolbarDefaults.animationSpec(),
@@ -150,7 +157,7 @@ fun FloatingNavigationToolbar(
                         contentDescription = fabContentDescription,
                     )
                 },
-                modifier = Modifier.widthIn(max = 480.dp),
+                modifier = toolbarModifier,
                 colors = toolbarColors,
                 scrollBehavior = scrollBehavior,
                 animationSpec = FloatingToolbarDefaults.animationSpec(),
@@ -166,7 +173,11 @@ fun FloatingNavigationToolbar(
         } else {
             HorizontalFloatingToolbar(
                 expanded = true,
-                modifier = Modifier.widthIn(max = 420.dp),
+                modifier = Modifier
+                    .widthIn(max = 420.dp)
+                    .let {
+                        if (enableLiquidGlass) it.graphicsLayer { shadowElevation = 0f } else it
+                    },
                 colors = toolbarColors,
                 scrollBehavior = scrollBehavior,
             ) {
@@ -245,7 +256,7 @@ private fun ToolbarItemsContainer(
                     .fillMaxHeight()
                     .background(
                         color = floatingToolbarSelectedItemContainerColor(pureBlack),
-                        shape = RoundedCornerShape(24.dp)
+                        shape = CircleShape
                     )
             )
         }
@@ -406,7 +417,7 @@ private fun FloatingNavigationToolbarItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val shape = RoundedCornerShape(24.dp)
+    val shape = CircleShape
     val showLabel = selected && showSelectedLabel && screen.route != Screens.Search.route
     val transition = updateTransition(targetState = selected, label = "navItem_${screen.route}")
 

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/FloatingNavigationToolbar.kt
@@ -77,7 +77,10 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.arturo254.opentune.R
 import com.arturo254.opentune.ui.screens.Screens
-import kotlin.text.get
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.animation.core.Animatable
+import com.arturo254.opentune.constants.EnableLiquidGlassKey
+import com.arturo254.opentune.utils.rememberPreference
 
 @Composable
 fun FloatingNavigationToolbar(
@@ -96,7 +99,8 @@ fun FloatingNavigationToolbar(
     isSelected: (Screens) -> Boolean,
     onItemClick: (Screens, Boolean) -> Unit,
 ) {
-    val toolbarContainerColor = floatingToolbarContainerColor(pureBlack = pureBlack)
+    val enableLiquidGlass by rememberPreference(EnableLiquidGlassKey, defaultValue = false)
+    val toolbarContainerColor = if (enableLiquidGlass) Color.Transparent else floatingToolbarContainerColor(pureBlack = pureBlack)
     val toolbarColors = FloatingToolbarDefaults.standardFloatingToolbarColors(
         toolbarContainerColor = toolbarContainerColor,
     )
@@ -212,7 +216,25 @@ private fun ToolbarItemsContainer(
         label = "pillOffset"
     )
 
-    Box(modifier = Modifier.height(IntrinsicSize.Min)) {
+    val enableLiquidGlass by rememberPreference(EnableLiquidGlassKey, defaultValue = false)
+    val layer = rememberGraphicsLayer()
+    val luminanceAnimation = remember { Animatable(0.3f) }
+    val backdrop = LocalBackdrop.current
+
+    Box(
+        modifier = Modifier
+            .let {
+                if (enableLiquidGlass && backdrop != null) {
+                    it.drawBackdropCustomShape(
+                        backdrop = backdrop,
+                        layer = layer,
+                        luminanceAnimation = luminanceAnimation.value,
+                        shape = CircleShape
+                    )
+                } else it
+            }
+            .height(IntrinsicSize.Min)
+    ) {
         if (targetWidth > 0.dp) {
             Box(
                 modifier = Modifier

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/FloatingNavigationToolbar.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/FloatingNavigationToolbar.kt
@@ -225,12 +225,14 @@ private fun ToolbarItemsContainer(
         modifier = Modifier
             .let {
                 if (enableLiquidGlass && backdrop != null) {
-                    it.drawBackdropCustomShape(
-                        backdrop = backdrop,
-                        layer = layer,
-                        luminanceAnimation = luminanceAnimation.value,
-                        shape = CircleShape
-                    )
+                    it
+                        .drawBackdropCustomShape(
+                            backdrop = backdrop,
+                            layer = layer,
+                            luminanceAnimation = luminanceAnimation.value,
+                            shape = CircleShape
+                        )
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
                 } else it
             }
             .height(IntrinsicSize.Min)

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/LiquidGlass.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/LiquidGlass.kt
@@ -1,0 +1,84 @@
+package com.arturo254.opentune.ui.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.layer.GraphicsLayer
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.kyant.backdrop.backdrops.LayerBackdrop
+import com.kyant.backdrop.backdrops.rememberLayerBackdrop
+import com.kyant.backdrop.drawBackdrop
+import com.kyant.backdrop.effects.blur
+import com.kyant.backdrop.effects.colorControls
+import com.kyant.backdrop.effects.lens
+import com.kyant.backdrop.effects.vibrancy
+import kotlin.math.sign
+import com.kyant.backdrop.backdrops.layerBackdrop as nativeBackdrop
+
+typealias PlatformBackdrop = LayerBackdrop
+
+val LocalBackdrop = staticCompositionLocalOf<PlatformBackdrop?> { null }
+
+@Composable
+fun rememberBackdrop(): PlatformBackdrop = rememberLayerBackdrop {
+    drawRect(Color.Black)
+    drawContent()
+}
+
+fun Modifier.layerBackdrop(backdrop: PlatformBackdrop): Modifier = this.nativeBackdrop(backdrop)
+
+fun Modifier.drawBackdropCustomShape(
+    backdrop: PlatformBackdrop,
+    layer: GraphicsLayer,
+    luminanceAnimation: Float,
+    shape: Shape
+): Modifier {
+    return this.drawBackdrop(
+        backdrop = backdrop,
+        effects = {
+            val l = (luminanceAnimation * 2f - 1f).let { sign(it) * it * it }
+            vibrancy()
+            colorControls(
+                brightness =
+                    if (l > 0f) {
+                        lerp(0.1f, 0.5f, l)
+                    } else {
+                        lerp(0.1f, -0.2f, -l)
+                    },
+                contrast =
+                    if (l > 0f) {
+                        lerp(1f, 0f, l)
+                    } else {
+                        1f
+                    },
+                saturation = 1.5f,
+            )
+            blur(
+                if (l > 0f) {
+                    lerp(8f.dp.toPx(), 16f.dp.toPx(), l)
+                } else {
+                    lerp(8f.dp.toPx(), 2f.dp.toPx(), -l)
+                },
+            )
+            lens(24f.dp.toPx(), size.minDimension / 2f, true)
+        },
+        onDrawBackdrop = { drawBackdrop ->
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                drawBackdrop()
+            }
+        },
+        shape = { shape },
+        onDrawSurface = {
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
+                drawRect(Color.Black.copy(alpha = 0.1f))
+            } else {
+                // Fallback for Android 11 and below since RenderEffect blur isn't supported
+                // We use a dark color (since this is mostly used in dark themes) or surface color
+                drawRect(Color(0xE6121212)) // 90% opaque dark gray (standard dark surface)
+            }
+        }
+    )
+}

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/player/MiniPlayer.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/player/MiniPlayer.kt
@@ -30,6 +30,13 @@ import com.arturo254.opentune.constants.SwipeSensitivityKey
 import com.arturo254.opentune.ui.component.BottomSheetState
 import com.arturo254.opentune.utils.rememberPreference
 import kotlin.math.roundToInt
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.rememberGraphicsLayer
+import androidx.compose.animation.core.Animatable
+import androidx.compose.runtime.remember
+import com.arturo254.opentune.constants.EnableLiquidGlassKey
+import com.arturo254.opentune.ui.component.LocalBackdrop
+import com.arturo254.opentune.ui.component.drawBackdropCustomShape
 
 
 @Composable
@@ -65,6 +72,13 @@ private fun NewMiniPlayer(
     val coroutineScope = rememberCoroutineScope()
     val swipeSensitivity by rememberPreference(SwipeSensitivityKey, 0.73f)
     val swipeThumbnail by rememberPreference(com.arturo254.opentune.constants.SwipeThumbnailKey, true)
+    val enableLiquidGlass by rememberPreference(EnableLiquidGlassKey, defaultValue = false)
+
+    val layer = rememberGraphicsLayer()
+    val luminanceAnimation = remember { Animatable(0.3f) }
+    val backdrop = LocalBackdrop.current
+
+    val backgroundColor = MaterialTheme.colorScheme.surfaceContainer
 
     SwipeableMiniPlayerBox(
         modifier = modifier,
@@ -81,8 +95,18 @@ private fun NewMiniPlayer(
                 .fillMaxWidth()
                 .height(64.dp)
                 .offset { IntOffset(offsetX.roundToInt(), 0) }
+                .let {
+                    if (enableLiquidGlass && backdrop != null) {
+                        it.drawBackdropCustomShape(
+                            backdrop = backdrop,
+                            layer = layer,
+                            luminanceAnimation = luminanceAnimation.value,
+                            shape = RoundedCornerShape(32.dp)
+                        )
+                    } else it
+                }
                 .clip(RoundedCornerShape(32.dp))
-                .background(color = MaterialTheme.colorScheme.surfaceContainer)
+                .background(color = if (enableLiquidGlass) Color.Transparent else backgroundColor)
         ) {
             NewMiniPlayerContent(
                 pureBlack = pureBlack,

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/player/Player.kt
@@ -135,6 +135,7 @@ import com.arturo254.opentune.constants.PlayerDesignStyleKey
 import com.arturo254.opentune.constants.UseNewMiniPlayerDesignKey
 import com.arturo254.opentune.constants.PlayerBackgroundStyle
 import com.arturo254.opentune.constants.PlayerBackgroundStyleKey
+import com.arturo254.opentune.constants.EnableLiquidGlassKey
 import com.arturo254.opentune.constants.PlayerCustomImageUriKey
 import com.arturo254.opentune.constants.PlayerCustomBlurKey
 import com.arturo254.opentune.constants.PlayerCustomContrastKey
@@ -341,7 +342,12 @@ fun BottomSheetPlayer(
                 if (darkTheme == DarkMode.AUTO) isSystemInDarkTheme else darkTheme == DarkMode.ON
             useDarkTheme && pureBlack
         }
-    val backgroundColor = if (useBlackBackground && state.value > state.collapsedBound) {
+    val enableLiquidGlass by rememberPreference(EnableLiquidGlassKey, defaultValue = false)
+    val backgroundColor = if (enableLiquidGlass) {
+        val progress = ((state.value - state.collapsedBound) / (state.expandedBound - state.collapsedBound))
+            .coerceIn(0f, 1f)
+        Color.White.copy(alpha = 0.1f * progress)
+    } else if (useBlackBackground && state.value > state.collapsedBound) {
         val progress = ((state.value - state.collapsedBound) / (state.expandedBound - state.collapsedBound))
             .coerceIn(0f, 1f)
         Color.Black.copy(alpha = progress)

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/AppearanceSettings.kt
@@ -93,6 +93,7 @@ import com.arturo254.opentune.constants.CropThumbnailToSquareKey
 import com.arturo254.opentune.constants.DisableBlurKey
 import com.arturo254.opentune.constants.EnableHapticFeedbackKey
 import com.arturo254.opentune.constants.LiquidGlassNavBarKey
+import com.arturo254.opentune.constants.EnableLiquidGlassKey
 import com.arturo254.opentune.constants.PlayerFullscreenKey
 import com.arturo254.opentune.constants.UseLyricsV2Key
 import com.arturo254.opentune.ui.component.DefaultDialog
@@ -127,6 +128,10 @@ fun AppearanceSettings(
     val (darkMode, onDarkModeChange) = rememberEnumPreference(
         DarkModeKey,
         defaultValue = DarkMode.AUTO
+    )
+    val (enableLiquidGlass, onEnableLiquidGlassChange) = rememberPreference(
+        EnableLiquidGlassKey,
+        defaultValue = false
     )
     val (playerDesignStyle, onPlayerDesignStyleChange) = rememberEnumPreference(
         PlayerDesignStyleKey,
@@ -367,26 +372,49 @@ fun AppearanceSettings(
             )
         }
 
+        SwitchPreference(
+            title = { Text(stringResource(R.string.enable_liquid_glass)) },
+            description = stringResource(R.string.enable_liquid_glass_desc),
+            icon = { Icon(painterResource(R.drawable.palette), null) },
+            checked = enableLiquidGlass,
+            onCheckedChange = { newValue ->
+                onEnableLiquidGlassChange(newValue)
+                if (newValue) {
+                    onDarkModeChange(DarkMode.ON)
+                }
+            },
+        )
+
         EnumListPreference(
             title = { Text(stringResource(R.string.dark_theme)) },
             icon = { Icon(painterResource(R.drawable.dark_mode), null) },
-            selectedValue = darkMode,
+            selectedValue = if (enableLiquidGlass) DarkMode.ON else darkMode,
             onValueSelected = onDarkModeChange,
             valueText = {
-                when (it) {
-                    DarkMode.ON -> stringResource(R.string.dark_theme_on)
-                    DarkMode.OFF -> stringResource(R.string.dark_theme_off)
-                    DarkMode.AUTO -> stringResource(R.string.dark_theme_follow_system)
+                if (enableLiquidGlass) {
+                    stringResource(R.string.dark_theme_on)
+                } else {
+                    when (it) {
+                        DarkMode.ON -> stringResource(R.string.dark_theme_on)
+                        DarkMode.OFF -> stringResource(R.string.dark_theme_off)
+                        DarkMode.AUTO -> stringResource(R.string.dark_theme_follow_system)
+                    }
                 }
             },
+            isEnabled = !enableLiquidGlass
         )
 
         AnimatedVisibility(useDarkTheme) {
             SwitchPreference(
                 title = { Text(stringResource(R.string.pure_black)) },
                 icon = { Icon(painterResource(R.drawable.contrast), null) },
-                checked = pureBlack,
-                onCheckedChange = onPureBlackChange,
+                checked = pureBlack && useDarkTheme && !enableLiquidGlass,
+                onCheckedChange = { newValue ->
+                    if (useDarkTheme && !enableLiquidGlass) {
+                        onPureBlackChange(newValue)
+                    }
+                },
+                isEnabled = useDarkTheme && !enableLiquidGlass
             )
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -355,6 +355,8 @@
     <!-- End of Color Palette -->
 
     <string name="dark_theme">Dark theme</string>
+    <string name="enable_liquid_glass">Enable Liquid Glass</string>
+    <string name="enable_liquid_glass_desc">Apply frosted glass blur and vibrancy to the bottom navigation and miniplayer. Automatically forces dark theme.</string>
     <string name="dark_theme_on">On</string>
     <string name="dark_theme_off">Off</string>
     <string name="show_button">Show button</string>


### PR DESCRIPTION

### Summary of Changes

#### 1. Liquid Glass Backdrop System
- Integrated `LiquidGlass.kt` with custom backdrop rendering (`drawBackdropCustomShape`) powered by `LayerBackdrop` for Android 12+ (SDK 31+).
- Included fallback rendering for older Android versions.
- Added `EnableLiquidGlassKey` in **Appearance Settings** to let users toggle the Liquid Glass frosted glass effect on or off.

#### 2. Floating Navigation Toolbar
- Applied Liquid Glass frosted glass backdrop to the main navigation pill (`ToolbarItemsContainer`).
- Restricted the backdrop pill bounds so that it starts before the Home button and ends cleanly right after the Library/Grid button.
- Kept the 3-dot Floating Action Button (`FloatingToolbarOverflowAction`) separate on the right side without overlapping backdrop interference.
- Updated the active item container and tab indicator shape to `CircleShape` for clean, modern circular active indicators.
- Removed container shadow elevation (`shadowElevation = 0f`) when Liquid Glass mode is enabled.

#### 3. Mini Player
- Applied Liquid Glass frosted glass backdrop to the `MiniPlayer` with `32.dp` rounded corner radius, providing visual consistency across bottom UI elements.

---

### Verification
- Tested with Liquid Glass enabled and disabled in Appearance Settings.
- Verified on ARM64 Debug builds (`./gradlew assembleArm64Debug`).


-Preview

<img width="576" height="1280" alt="6271502480050950648_121" src="https://github.com/user-attachments/assets/429a0ac4-d0bb-447a-9621-cfa0fe8968f4" />