### PR TITLE
feat(player): add Spotify player style with animated sticky header & live synced lyrics

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/constants/PreferenceKeys.kt
@@ -409,7 +409,8 @@ enum class PlayerDesignStyle {
     V5,
     V6,
     V7,
-    V8
+    V8,
+    SPOTIFY
 }
 
 enum class PlayerBackgroundStyle {

--- a/app/src/main/kotlin/com/arturo254/opentune/constants/PreferenceKeys.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/constants/PreferenceKeys.kt
@@ -422,6 +422,7 @@ enum class PlayerBackgroundStyle {
     BLUR_GRADIENT,
     GLOW,
     GLOW_ANIMATED,
+    SPOTIFY
 }
 
 // Keys for customized background

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/player/LyricsScreen.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/player/LyricsScreen.kt
@@ -183,7 +183,7 @@ fun LyricsScreen(
     val fallbackColor = MaterialTheme.colorScheme.surface.toArgb()
 
     LaunchedEffect(mediaMetadata.id, playerBackground) {
-        if (playerBackground == PlayerBackgroundStyle.GRADIENT || playerBackground == PlayerBackgroundStyle.COLORING || playerBackground == PlayerBackgroundStyle.BLUR_GRADIENT || playerBackground == PlayerBackgroundStyle.GLOW || playerBackground == PlayerBackgroundStyle.GLOW_ANIMATED) {
+        if (playerBackground == PlayerBackgroundStyle.SPOTIFY || playerBackground == PlayerBackgroundStyle.GRADIENT || playerBackground == PlayerBackgroundStyle.COLORING || playerBackground == PlayerBackgroundStyle.BLUR_GRADIENT || playerBackground == PlayerBackgroundStyle.GLOW || playerBackground == PlayerBackgroundStyle.GLOW_ANIMATED) {
             if (mediaMetadata.thumbnailUrl != null) {
                 val cachedColors = gradientColorsCache[mediaMetadata.id]
                 if (cachedColors != null) {
@@ -241,6 +241,7 @@ fun LyricsScreen(
         PlayerBackgroundStyle.GLOW -> Color.White
         PlayerBackgroundStyle.GLOW_ANIMATED -> Color.White
         PlayerBackgroundStyle.CUSTOM -> Color.White
+        PlayerBackgroundStyle.SPOTIFY -> Color.White
     }
 
     val icBackgroundColor = when (playerBackground) {
@@ -252,6 +253,7 @@ fun LyricsScreen(
         PlayerBackgroundStyle.GLOW -> Color.Black
         PlayerBackgroundStyle.GLOW_ANIMATED -> Color.Black
         PlayerBackgroundStyle.CUSTOM -> Color.Black
+        PlayerBackgroundStyle.SPOTIFY -> Color.Black
     }
 
     LaunchedEffect(playbackState) {

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/player/Player.kt
@@ -16,6 +16,7 @@ import android.content.res.Configuration
 import android.os.SystemClock
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -23,6 +24,8 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -119,6 +122,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.media3.common.C
 import androidx.media3.common.Player.STATE_BUFFERING
+import androidx.media3.common.Player.STATE_ENDED
 import androidx.media3.common.Player.STATE_READY
 import androidx.palette.graphics.Palette
 import androidx.navigation.NavController
@@ -148,6 +152,7 @@ import com.arturo254.opentune.constants.QueuePeekHeight
 import com.arturo254.opentune.constants.SliderStyle
 import com.arturo254.opentune.constants.SliderStyleKey
 import com.arturo254.opentune.extensions.togglePlayPause
+import com.arturo254.opentune.extensions.toggleRepeatMode
 import com.arturo254.opentune.extensions.metadata
 import com.arturo254.opentune.models.MediaMetadata
 import com.arturo254.opentune.ui.component.BottomSheet
@@ -362,11 +367,13 @@ fun BottomSheetPlayer(
     val currentSong by playerConnection.currentSong.collectAsState(initial = null)
     val currentSongLiked = currentSong?.song?.liked == true
     val currentFormat by playerConnection.currentFormat.collectAsState(initial = null)
+    val currentLyrics by playerConnection.currentLyrics.collectAsState(initial = null)
     val queueWindows by playerConnection.queueWindows.collectAsState()
     val currentWindowIndex by playerConnection.currentWindowIndex.collectAsState()
     val playerVolume = playerConnection.service.playerVolume.collectAsState()
 
     val repeatMode by playerConnection.repeatMode.collectAsState()
+    val shuffleModeEnabled by playerConnection.shuffleModeEnabled.collectAsState()
 
     val canSkipPrevious by playerConnection.canSkipPrevious.collectAsState()
     val canSkipNext by playerConnection.canSkipNext.collectAsState()
@@ -415,8 +422,8 @@ fun BottomSheetPlayer(
         }
     }
 
-    LaunchedEffect(mediaMetadata?.id, playerBackground) {
-        if (playerBackground == PlayerBackgroundStyle.GRADIENT || playerBackground == PlayerBackgroundStyle.COLORING || playerBackground == PlayerBackgroundStyle.BLUR_GRADIENT || playerBackground == PlayerBackgroundStyle.GLOW || playerBackground == PlayerBackgroundStyle.GLOW_ANIMATED) {
+    LaunchedEffect(mediaMetadata?.id, playerBackground, playerDesignStyle) {
+        if (playerDesignStyle == PlayerDesignStyle.SPOTIFY || playerBackground == PlayerBackgroundStyle.GRADIENT || playerBackground == PlayerBackgroundStyle.COLORING || playerBackground == PlayerBackgroundStyle.BLUR_GRADIENT || playerBackground == PlayerBackgroundStyle.GLOW || playerBackground == PlayerBackgroundStyle.GLOW_ANIMATED) {
             val currentMetadata = mediaMetadata
             if (currentMetadata != null && currentMetadata.thumbnailUrl != null) {
                 // Check cache first
@@ -1158,6 +1165,113 @@ fun BottomSheetPlayer(
                             Spacer(Modifier.height(16.dp))
                         }
                     }
+                } else if (playerDesignStyle == PlayerDesignStyle.SPOTIFY) {
+                    Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+                        val spotifyScrollState = rememberScrollState()
+                        SpotifyPlayerBackdrop(
+                            thumbnailUrl = mediaMetadata?.thumbnailUrl,
+                            accentColor = gradientColors.firstOrNull() ?: MaterialTheme.colorScheme.surfaceContainer,
+                            modifier = Modifier.fillMaxSize()
+                        )
+
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .nestedScroll(state.preUpPostDownNestedScrollConnection)
+                                .verticalScroll(spotifyScrollState)
+                                .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal))
+                                .padding(horizontal = 24.dp)
+                                .padding(bottom = queueSheetState.collapsedBound + 28.dp),
+                        ) {
+                            Spacer(Modifier.height(22.dp))
+
+                            mediaMetadata?.let { metadata ->
+                                SpotifyPlayerContent(
+                                    mediaMetadata = metadata,
+                                    position = sliderPosition ?: position,
+                                    duration = duration,
+                                    isPlaying = isPlaying,
+                                    isLoading = playbackState != STATE_READY && playbackState != STATE_ENDED,
+                                    canSkipPrevious = canSkipPrevious,
+                                    canSkipNext = canSkipNext,
+                                    repeatMode = repeatMode,
+                                    sliderStyle = sliderStyle,
+                                    lyricsPreview = currentLyrics?.lyrics,
+                                    onSeek = onSliderValueChange,
+                                    onSeekFinished = onSliderValueChangeFinished,
+                                    onPlayPause = { playerConnection.player.togglePlayPause() },
+                                    onPrevious = { playerConnection.player.seekToPrevious() },
+                                    onNext = playerConnection::seekToNext,
+                                    onShuffle = { playerConnection.player.shuffleModeEnabled = !playerConnection.player.shuffleModeEnabled },
+                                    onRepeat = { playerConnection.player.toggleRepeatMode() },
+                                    onOpenLyrics = { lyricsSheetState.expandSoft() },
+                                    onOpenQueue = { queueSheetState.expandSoft() },
+                                    onCollapse = state::collapseSoft,
+                                    onOpenArtist = { artistId ->
+                                        navController.navigate("artist/$artistId")
+                                        state.collapseSoft()
+                                    },
+                                    onOpenMenu = {
+                                        menuState.show {
+                                            PlayerMenu(
+                                                mediaMetadata = metadata,
+                                                navController = navController,
+                                                playerBottomSheetState = state,
+                                                onShowDetailsDialog = {
+                                                    bottomSheetPageState.show {
+                                                        ShowMediaInfo(metadata.id)
+                                                    }
+                                                },
+                                                onDismiss = menuState::dismiss
+                                            )
+                                        }
+                                    },
+                                    isLiked = currentSongLiked,
+                                    onLike = playerConnection::toggleLike,
+                                    onAddToPlaylist = { showChoosePlaylistDialog = true },
+                                    onShowDetails = {
+                                        bottomSheetPageState.show {
+                                            ShowMediaInfo(metadata.id)
+                                        }
+                                    },
+                                    shuffleModeEnabled = shuffleModeEnabled,
+                                    currentSongArtists = currentSong?.artists ?: emptyList(),
+                                )
+                            }
+                        }
+
+                        mediaMetadata?.let { metadata ->
+                            AnimatedVisibility(
+                                visible = spotifyScrollState.value > 400,
+                                enter = fadeIn(tween(180)),
+                                exit = fadeOut(tween(180)),
+                                modifier = Modifier.align(Alignment.TopCenter),
+                            ) {
+                                SpotifyCollapsedHeader(
+                                    mediaMetadata = metadata,
+                                    surfaceColor = MaterialTheme.colorScheme.surfaceContainer,
+                                    isLiked = currentSongLiked,
+                                    onLike = playerConnection::toggleLike,
+                                    onOpenMenu = {
+                                        menuState.show {
+                                            PlayerMenu(
+                                                mediaMetadata = metadata,
+                                                navController = navController,
+                                                playerBottomSheetState = state,
+                                                onShowDetailsDialog = {
+                                                    bottomSheetPageState.show {
+                                                        ShowMediaInfo(metadata.id)
+                                                    }
+                                                },
+                                                onDismiss = menuState::dismiss
+                                            )
+                                        }
+                                    },
+                                )
+                            }
+                        }
+                    }
                 } else {
                     Row(
                         modifier =
@@ -1366,6 +1480,113 @@ fun BottomSheetPlayer(
                             }
 
                             Spacer(Modifier.height(24.dp))
+                        }
+                    }
+                } else if (playerDesignStyle == PlayerDesignStyle.SPOTIFY) {
+                    Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
+                        val spotifyScrollState = rememberScrollState()
+                        SpotifyPlayerBackdrop(
+                            thumbnailUrl = mediaMetadata?.thumbnailUrl,
+                            accentColor = gradientColors.firstOrNull() ?: MaterialTheme.colorScheme.surfaceContainer,
+                            modifier = Modifier.fillMaxSize()
+                        )
+
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .nestedScroll(state.preUpPostDownNestedScrollConnection)
+                                .verticalScroll(spotifyScrollState)
+                                .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Horizontal))
+                                .padding(horizontal = 24.dp)
+                                .padding(bottom = queueSheetState.collapsedBound + 28.dp),
+                        ) {
+                            Spacer(Modifier.height(22.dp))
+
+                            mediaMetadata?.let { metadata ->
+                                SpotifyPlayerContent(
+                                    mediaMetadata = metadata,
+                                    position = sliderPosition ?: position,
+                                    duration = duration,
+                                    isPlaying = isPlaying,
+                                    isLoading = playbackState != STATE_READY && playbackState != STATE_ENDED,
+                                    canSkipPrevious = canSkipPrevious,
+                                    canSkipNext = canSkipNext,
+                                    repeatMode = repeatMode,
+                                    sliderStyle = sliderStyle,
+                                    lyricsPreview = currentLyrics?.lyrics,
+                                    onSeek = onSliderValueChange,
+                                    onSeekFinished = onSliderValueChangeFinished,
+                                    onPlayPause = { playerConnection.player.togglePlayPause() },
+                                    onPrevious = { playerConnection.player.seekToPrevious() },
+                                    onNext = playerConnection::seekToNext,
+                                    onShuffle = { playerConnection.player.shuffleModeEnabled = !playerConnection.player.shuffleModeEnabled },
+                                    onRepeat = { playerConnection.player.toggleRepeatMode() },
+                                    onOpenLyrics = { lyricsSheetState.expandSoft() },
+                                    onOpenQueue = { queueSheetState.expandSoft() },
+                                    onCollapse = state::collapseSoft,
+                                    onOpenArtist = { artistId ->
+                                        navController.navigate("artist/$artistId")
+                                        state.collapseSoft()
+                                    },
+                                    onOpenMenu = {
+                                        menuState.show {
+                                            PlayerMenu(
+                                                mediaMetadata = metadata,
+                                                navController = navController,
+                                                playerBottomSheetState = state,
+                                                onShowDetailsDialog = {
+                                                    bottomSheetPageState.show {
+                                                        ShowMediaInfo(metadata.id)
+                                                    }
+                                                },
+                                                onDismiss = menuState::dismiss
+                                            )
+                                        }
+                                    },
+                                    isLiked = currentSongLiked,
+                                    onLike = playerConnection::toggleLike,
+                                    onAddToPlaylist = { showChoosePlaylistDialog = true },
+                                    onShowDetails = {
+                                        bottomSheetPageState.show {
+                                            ShowMediaInfo(metadata.id)
+                                        }
+                                    },
+                                    shuffleModeEnabled = shuffleModeEnabled,
+                                    currentSongArtists = currentSong?.artists ?: emptyList(),
+                                )
+                            }
+                        }
+
+                        mediaMetadata?.let { metadata ->
+                            AnimatedVisibility(
+                                visible = spotifyScrollState.value > 400,
+                                enter = fadeIn(tween(180)),
+                                exit = fadeOut(tween(180)),
+                                modifier = Modifier.align(Alignment.TopCenter),
+                            ) {
+                                SpotifyCollapsedHeader(
+                                    mediaMetadata = metadata,
+                                    surfaceColor = MaterialTheme.colorScheme.surfaceContainer,
+                                    isLiked = currentSongLiked,
+                                    onLike = playerConnection::toggleLike,
+                                    onOpenMenu = {
+                                        menuState.show {
+                                            PlayerMenu(
+                                                mediaMetadata = metadata,
+                                                navController = navController,
+                                                playerBottomSheetState = state,
+                                                onShowDetailsDialog = {
+                                                    bottomSheetPageState.show {
+                                                        ShowMediaInfo(metadata.id)
+                                                    }
+                                                },
+                                                onDismiss = menuState::dismiss
+                                            )
+                                        }
+                                    },
+                                )
+                            }
                         }
                     }
                 } else {

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/player/Player.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/player/Player.kt
@@ -423,7 +423,7 @@ fun BottomSheetPlayer(
     }
 
     LaunchedEffect(mediaMetadata?.id, playerBackground, playerDesignStyle) {
-        if (playerDesignStyle == PlayerDesignStyle.SPOTIFY || playerBackground == PlayerBackgroundStyle.GRADIENT || playerBackground == PlayerBackgroundStyle.COLORING || playerBackground == PlayerBackgroundStyle.BLUR_GRADIENT || playerBackground == PlayerBackgroundStyle.GLOW || playerBackground == PlayerBackgroundStyle.GLOW_ANIMATED) {
+        if (playerDesignStyle == PlayerDesignStyle.SPOTIFY || playerBackground == PlayerBackgroundStyle.SPOTIFY || playerBackground == PlayerBackgroundStyle.GRADIENT || playerBackground == PlayerBackgroundStyle.COLORING || playerBackground == PlayerBackgroundStyle.BLUR_GRADIENT || playerBackground == PlayerBackgroundStyle.GLOW || playerBackground == PlayerBackgroundStyle.GLOW_ANIMATED) {
             val currentMetadata = mediaMetadata
             if (currentMetadata != null && currentMetadata.thumbnailUrl != null) {
                 // Check cache first
@@ -488,6 +488,7 @@ fun BottomSheetPlayer(
             PlayerBackgroundStyle.GLOW -> Color.White
             PlayerBackgroundStyle.GLOW_ANIMATED -> Color.White
             PlayerBackgroundStyle.CUSTOM -> Color.White
+            PlayerBackgroundStyle.SPOTIFY -> Color.White
         }
 
     val icBackgroundColor =
@@ -501,6 +502,7 @@ fun BottomSheetPlayer(
             PlayerBackgroundStyle.GLOW -> Color.Black
             PlayerBackgroundStyle.GLOW_ANIMATED -> Color.Black
             PlayerBackgroundStyle.CUSTOM -> Color.Black
+            PlayerBackgroundStyle.SPOTIFY -> Color.Black
         }
 
     val (textButtonColor, iconButtonColor) = when (playerButtonsStyle) {
@@ -1253,6 +1255,10 @@ fun BottomSheetPlayer(
                                     surfaceColor = MaterialTheme.colorScheme.surfaceContainer,
                                     isLiked = currentSongLiked,
                                     onLike = playerConnection::toggleLike,
+                                    onOpenArtist = { artistId ->
+                                        navController.navigate("artist/$artistId")
+                                        state.collapseSoft()
+                                    },
                                     onOpenMenu = {
                                         menuState.show {
                                             PlayerMenu(
@@ -1570,6 +1576,10 @@ fun BottomSheetPlayer(
                                     surfaceColor = MaterialTheme.colorScheme.surfaceContainer,
                                     isLiked = currentSongLiked,
                                     onLike = playerConnection::toggleLike,
+                                    onOpenArtist = { artistId ->
+                                        navController.navigate("artist/$artistId")
+                                        state.collapseSoft()
+                                    },
                                     onOpenMenu = {
                                         menuState.show {
                                             PlayerMenu(

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/player/PlayerComponents.kt
@@ -2731,6 +2731,14 @@ fun PlayerBackground(
                 }
             }
 
+            PlayerBackgroundStyle.SPOTIFY -> {
+                SpotifyPlayerBackdrop(
+                    thumbnailUrl = mediaMetadata?.thumbnailUrl,
+                    accentColor = gradientColors.firstOrNull() ?: MaterialTheme.colorScheme.surfaceContainer,
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+
             else -> {
                 // DEFAULT or other modes - no background
             }
@@ -3444,6 +3452,7 @@ fun SpotifyCollapsedHeader(
     isLiked: Boolean,
     onLike: () -> Unit,
     onOpenMenu: () -> Unit,
+    onOpenArtist: (String) -> Unit = {},
 ) {
     Row(
         modifier = Modifier
@@ -3472,14 +3481,20 @@ fun SpotifyCollapsedHeader(
                 modifier = Modifier.basicMarquee(),
             )
             Spacer(Modifier.height(2.dp))
-            Text(
-                text = mediaMetadata.artists.joinToString { it.name },
-                style = MaterialTheme.typography.bodyMedium.copy(fontSize = 13.sp, fontWeight = FontWeight.Normal),
-                color = Color.White.copy(alpha = 0.68f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.basicMarquee(),
-            )
+            Row(modifier = Modifier.basicMarquee()) {
+                mediaMetadata.artists.forEachIndexed { index, artist ->
+                    Text(
+                        text = artist.name + if (index < mediaMetadata.artists.lastIndex) ", " else "",
+                        style = MaterialTheme.typography.bodyMedium.copy(fontSize = 13.sp, fontWeight = FontWeight.Normal),
+                        color = Color.White.copy(alpha = 0.68f),
+                        modifier = Modifier.clickable {
+                            artist.id?.let { artistId ->
+                                if (artistId.isNotBlank()) onOpenArtist(artistId)
+                            }
+                        }
+                    )
+                }
+            }
         }
         Spacer(Modifier.width(16.dp))
         SpotifyRoundIconButton(
@@ -3636,14 +3651,20 @@ fun SpotifyPlayerContent(
                 modifier = Modifier.basicMarquee()
             )
             Spacer(Modifier.height(4.dp))
-            Text(
-                text = artists,
-                style = MaterialTheme.typography.bodyLarge.copy(fontSize = 18.sp, fontWeight = FontWeight.Normal),
-                color = Color.White.copy(alpha = 0.68f),
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.basicMarquee()
-            )
+            Row(modifier = Modifier.basicMarquee()) {
+                mediaMetadata.artists.forEachIndexed { index, artist ->
+                    Text(
+                        text = artist.name + if (index < mediaMetadata.artists.lastIndex) ", " else "",
+                        style = MaterialTheme.typography.bodyLarge.copy(fontSize = 18.sp, fontWeight = FontWeight.Normal),
+                        color = Color.White.copy(alpha = 0.68f),
+                        modifier = Modifier.clickable {
+                            artist.id?.let { artistId ->
+                                if (artistId.isNotBlank()) onOpenArtist(artistId)
+                            }
+                        }
+                    )
+                }
+            }
         }
         SpotifyRoundIconButton(
             icon = if (isLiked) R.drawable.favorite else R.drawable.favorite_border,

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/player/PlayerComponents.kt
@@ -36,6 +36,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -47,7 +48,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularWavyProgressIndicator
@@ -65,8 +71,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.withContext
+import com.arturo254.opentune.LocalDatabase
+import com.arturo254.opentune.innertube.YouTube
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -106,6 +118,7 @@ import com.arturo254.opentune.constants.PlayerBackgroundStyle
 import com.arturo254.opentune.constants.PlayerDesignStyle
 import com.arturo254.opentune.constants.PlayerHorizontalPadding
 import com.arturo254.opentune.constants.SliderStyle
+import com.arturo254.opentune.db.entities.ArtistEntity
 import com.arturo254.opentune.db.entities.FormatEntity
 import com.arturo254.opentune.extensions.togglePlayPause
 import com.arturo254.opentune.extensions.toggleRepeatMode
@@ -749,6 +762,7 @@ fun PlayerTopActions(
                 }
             }
         }
+        else -> {}
     }
 }
 
@@ -3419,6 +3433,656 @@ fun GlassTrack(
                         )
                     )
                 )
+        )
+    }
+}
+
+@Composable
+fun SpotifyCollapsedHeader(
+    mediaMetadata: MediaMetadata,
+    surfaceColor: Color = MaterialTheme.colorScheme.surfaceContainer,
+    isLiked: Boolean,
+    onLike: () -> Unit,
+    onOpenMenu: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(surfaceColor.copy(alpha = 0.96f))
+            .windowInsetsPadding(WindowInsets.systemBars.only(WindowInsetsSides.Top))
+            .padding(horizontal = 20.dp, vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        AsyncImage(
+            model = mediaMetadata.thumbnailUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .size(45.dp)
+                .clip(RoundedCornerShape(8.dp))
+        )
+        Spacer(Modifier.width(12.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = mediaMetadata.title,
+                style = MaterialTheme.typography.labelSmall.copy(fontSize = 14.sp, fontWeight = FontWeight.SemiBold),
+                color = Color.White,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.basicMarquee(),
+            )
+            Spacer(Modifier.height(2.dp))
+            Text(
+                text = mediaMetadata.artists.joinToString { it.name },
+                style = MaterialTheme.typography.bodyMedium.copy(fontSize = 13.sp, fontWeight = FontWeight.Normal),
+                color = Color.White.copy(alpha = 0.68f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.basicMarquee(),
+            )
+        }
+        Spacer(Modifier.width(16.dp))
+        SpotifyRoundIconButton(
+            icon = if (isLiked) R.drawable.favorite else R.drawable.favorite_border,
+            transparent = true,
+            tint = if (isLiked) Color(0xFF1DB954) else Color.White,
+            onClick = onLike
+        )
+        Spacer(Modifier.width(12.dp))
+        SpotifyRoundIconButton(icon = R.drawable.more_vert, transparent = true, onClick = onOpenMenu)
+    }
+}
+
+@Composable
+fun SpotifyPlayerBackdrop(
+    thumbnailUrl: String?,
+    accentColor: Color = Color.Black,
+    modifier: Modifier = Modifier,
+) {
+    val animatedAccentColor by androidx.compose.animation.animateColorAsState(
+        targetValue = accentColor,
+        animationSpec = tween(durationMillis = 800),
+        label = "spotifyAccentColor"
+    )
+    Box(modifier = modifier.background(Color.Black)) {
+        AsyncImage(
+            model = thumbnailUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier
+                .fillMaxSize()
+                .blur(110.dp)
+                .alpha(0.55f)
+                .graphicsLayer { scaleX = 1.25f; scaleY = 1.25f }
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0f to animatedAccentColor.copy(alpha = 0.55f),
+                            0.45f to Color.Black.copy(alpha = 0.65f),
+                            1f to Color.Black,
+                        )
+                    )
+                )
+        )
+    }
+}
+
+@Composable
+fun SpotifyPlayerContent(
+    mediaMetadata: MediaMetadata,
+    position: Long,
+    duration: Long,
+    isPlaying: Boolean,
+    isLoading: Boolean,
+    canSkipPrevious: Boolean,
+    canSkipNext: Boolean,
+    repeatMode: Int,
+    sliderStyle: SliderStyle,
+    lyricsPreview: String?,
+    onSeek: (Long) -> Unit,
+    onSeekFinished: () -> Unit,
+    onPlayPause: () -> Unit,
+    onPrevious: () -> Unit,
+    onNext: () -> Unit,
+    onShuffle: () -> Unit,
+    onRepeat: () -> Unit,
+    onOpenLyrics: () -> Unit,
+    onOpenQueue: () -> Unit,
+    onCollapse: () -> Unit,
+    onOpenArtist: (String) -> Unit,
+    onOpenMenu: () -> Unit,
+    isLiked: Boolean,
+    onLike: () -> Unit,
+    onAddToPlaylist: () -> Unit,
+    onShowDetails: () -> Unit,
+    shuffleModeEnabled: Boolean,
+    currentSongArtists: List<ArtistEntity> = emptyList(),
+    surfaceColor: Color = MaterialTheme.colorScheme.surfaceContainer,
+) {
+    val safeDuration = duration.takeIf { it > 0 } ?: 0L
+    val sliderValue = if (safeDuration > 0) position.coerceIn(0L, safeDuration).toFloat() else 0f
+    val artists = mediaMetadata.artists.joinToString { it.name }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 10.dp, bottom = 18.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            SpotifyRoundIconButton(
+                icon = R.drawable.expand_more,
+                transparent = true,
+                onClick = onCollapse,
+            )
+            Column(
+                modifier = Modifier.weight(1f),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text(
+                    text = androidx.compose.ui.res.stringResource(R.string.now_playing).uppercase(),
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 14.sp, fontWeight = FontWeight.SemiBold),
+                    color = Color.White,
+                )
+                Text(
+                    text = "\"${mediaMetadata.title}\"",
+                    style = MaterialTheme.typography.headlineSmall.copy(fontSize = 20.sp, fontWeight = FontWeight.Bold),
+                    color = Color.White,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.basicMarquee(),
+                )
+            }
+            SpotifyRoundIconButton(
+                icon = R.drawable.more_vert,
+                transparent = true,
+                onClick = onOpenMenu,
+            )
+        }
+    }
+
+    Spacer(Modifier.height(32.dp))
+
+    AsyncImage(
+        model = mediaMetadata.thumbnailUrl,
+        contentDescription = null,
+        contentScale = ContentScale.Crop,
+        modifier = Modifier
+            .fillMaxWidth(0.94f)
+            .aspectRatio(1f)
+            .clip(RoundedCornerShape(8.dp))
+    )
+
+    Spacer(Modifier.height(36.dp))
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = mediaMetadata.title,
+                style = MaterialTheme.typography.titleLarge.copy(fontSize = 25.sp, fontWeight = FontWeight.Bold),
+                color = Color.White,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.basicMarquee()
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text = artists,
+                style = MaterialTheme.typography.bodyLarge.copy(fontSize = 18.sp, fontWeight = FontWeight.Normal),
+                color = Color.White.copy(alpha = 0.68f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.basicMarquee()
+            )
+        }
+        SpotifyRoundIconButton(
+            icon = if (isLiked) R.drawable.favorite else R.drawable.favorite_border,
+            transparent = true,
+            tint = if (isLiked) Color(0xFF1DB954) else Color.White,
+            onClick = onLike
+        )
+    }
+
+    Spacer(Modifier.height(18.dp))
+
+    SpotifyStyledSlider(
+        value = sliderValue,
+        duration = safeDuration,
+        sliderStyle = sliderStyle,
+        isPlaying = isPlaying,
+        onSeek = onSeek,
+        onSeekFinished = onSeekFinished,
+        modifier = Modifier.fillMaxWidth(),
+    )
+
+    Row(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = makeTimeString(position.coerceAtLeast(0L)),
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White.copy(alpha = 0.68f),
+        )
+        Spacer(Modifier.weight(1f))
+        Text(
+            text = makeTimeString(safeDuration),
+            style = MaterialTheme.typography.labelMedium,
+            color = Color.White.copy(alpha = 0.68f),
+        )
+    }
+
+    Spacer(Modifier.height(12.dp))
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        SpotifyPlainIconButton(
+            if (shuffleModeEnabled) R.drawable.shuffle_on else R.drawable.shuffle,
+            onShuffle,
+            if (shuffleModeEnabled) Color(0xFF1DB954) else Color.White,
+        )
+        SpotifyPlainIconButton(
+            R.drawable.skip_previous,
+            onPrevious,
+            if (canSkipPrevious) Color.White else Color.White.copy(alpha = 0.32f),
+        )
+        Box(
+            modifier = Modifier
+                .size(74.dp)
+                .clip(CircleShape)
+                .background(Color.White)
+                .clickable(onClick = onPlayPause),
+            contentAlignment = Alignment.Center,
+        ) {
+            Image(
+                painter = painterResource(if (isPlaying && !isLoading) R.drawable.pause else R.drawable.play),
+                contentDescription = null,
+                colorFilter = ColorFilter.tint(Color.Black),
+                modifier = Modifier.size(38.dp)
+            )
+        }
+        SpotifyPlainIconButton(
+            R.drawable.skip_next,
+            onNext,
+            if (canSkipNext) Color.White else Color.White.copy(alpha = 0.32f),
+        )
+        SpotifyPlainIconButton(
+            if (repeatMode == Player.REPEAT_MODE_ONE) R.drawable.repeat_one else R.drawable.repeat,
+            onRepeat,
+            if (repeatMode == Player.REPEAT_MODE_OFF) Color.White else Color(0xFF1DB954),
+        )
+    }
+
+    Spacer(Modifier.height(22.dp))
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        SpotifyRoundIconButton(icon = R.drawable.info, transparent = true, onClick = onShowDetails)
+        Row(horizontalArrangement = Arrangement.spacedBy(24.dp)) {
+            SpotifyRoundIconButton(icon = R.drawable.playlist_add, transparent = true, onClick = onAddToPlaylist)
+            SpotifyRoundIconButton(icon = R.drawable.queue_music, transparent = true, onClick = onOpenQueue)
+        }
+    }
+
+    Spacer(Modifier.height(26.dp))
+
+    SpotifyLyricsPreviewCard(
+        lyrics = lyricsPreview,
+        position = position,
+        surfaceColor = surfaceColor,
+        onClick = onOpenLyrics,
+    )
+
+    Spacer(Modifier.height(12.dp))
+
+    mediaMetadata.artists.forEach { artist ->
+        val artistEntity = currentSongArtists.find { it.id == artist.id }
+        val thumbnailUrl = artistEntity?.thumbnailUrl?.takeIf { it.isNotBlank() } ?: mediaMetadata.thumbnailUrl
+        SpotifyArtistCard(
+            artist = artist.name,
+            artistId = artist.id,
+            thumbnailUrl = thumbnailUrl,
+            onClick = {
+                artist.id?.let { artistId ->
+                    onOpenArtist(artistId)
+                }
+            },
+        )
+        Spacer(Modifier.height(12.dp))
+    }
+
+    Spacer(Modifier.height(12.dp))
+
+    SpotifyDetailsCard(
+        mediaMetadata = mediaMetadata,
+        artists = artists,
+        surfaceColor = surfaceColor,
+        onClick = onOpenMenu,
+    )
+}
+
+@Composable
+private fun SpotifyStyledSlider(
+    value: Float,
+    duration: Long,
+    sliderStyle: SliderStyle,
+    isPlaying: Boolean,
+    onSeek: (Long) -> Unit,
+    onSeekFinished: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val valueRange = 0f..duration.coerceAtLeast(1L).toFloat()
+    StyledPlaybackSlider(
+        sliderStyle = sliderStyle,
+        value = value,
+        valueRange = valueRange,
+        onValueChange = { onSeek(it.toLong()) },
+        onValueChangeFinished = onSeekFinished,
+        activeColor = Color.White,
+        isPlaying = isPlaying,
+        modifier = modifier,
+    )
+}
+
+@Composable
+private fun SpotifyLyricsPreviewCard(
+    lyrics: String?,
+    position: Long,
+    surfaceColor: Color,
+    onClick: () -> Unit,
+) {
+    val lyricEntries = remember(lyrics) {
+        when {
+            lyrics.isNullOrBlank() || lyrics == com.arturo254.opentune.db.entities.LyricsEntity.LYRICS_NOT_FOUND -> emptyList()
+            lyrics.startsWith("[") -> com.arturo254.opentune.lyrics.LyricsUtils.parseLyrics(lyrics)
+            else -> lyrics.lines()
+                .map { it.trim() }
+                .filter { it.isNotBlank() }
+                .mapIndexed { index, line -> com.arturo254.opentune.lyrics.LyricsEntry(index * 2500L, line) }
+        }
+    }
+    val activeLineIndex = remember(lyricEntries, position) {
+        lyricEntries.indexOfLast { it.time <= position }.coerceAtLeast(0)
+    }
+    val listState = androidx.compose.foundation.lazy.rememberLazyListState()
+
+    androidx.compose.runtime.LaunchedEffect(activeLineIndex, lyricEntries.size) {
+        if (lyricEntries.isNotEmpty()) {
+            listState.animateScrollToItem(activeLineIndex.coerceAtMost(lyricEntries.lastIndex))
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(surfaceColor.copy(alpha = 0.9f))
+            .clickable(onClick = onClick)
+            .padding(15.dp),
+    ) {
+        Column {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = androidx.compose.ui.res.stringResource(R.string.lyrics),
+                    style = MaterialTheme.typography.labelMedium.copy(fontSize = 16.sp, fontWeight = FontWeight.Bold),
+                    color = Color.White,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    text = "Show",
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.Bold,
+                    color = Color.White.copy(alpha = 0.72f),
+                )
+            }
+
+            Spacer(Modifier.height(26.dp))
+
+            if (lyricEntries.isEmpty()) {
+                Text(
+                    text = androidx.compose.ui.res.stringResource(R.string.lyrics_not_found),
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.ExtraBold,
+                    color = Color.White.copy(alpha = 0.45f),
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(bottom = 20.dp),
+                )
+            } else {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(200.dp)
+                ) {
+                    androidx.compose.foundation.lazy.LazyColumn(
+                        state = listState,
+                        userScrollEnabled = false,
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                        modifier = Modifier.fillMaxSize()
+                    ) {
+                        items(lyricEntries.size) { index ->
+                            val isCurrent = index == activeLineIndex
+                            val isPast = index < activeLineIndex
+                            Text(
+                                text = lyricEntries[index].text,
+                                style = MaterialTheme.typography.headlineMedium.copy(fontSize = 20.sp, fontWeight = FontWeight.Bold),
+                                color = when {
+                                    isCurrent -> Color.White
+                                    isPast -> Color.White.copy(alpha = 0.5f)
+                                    else -> Color.White.copy(alpha = 0.25f)
+                                },
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        item {
+                            Spacer(Modifier.height(150.dp))
+                        }
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(18.dp))
+            Text(
+                text = if (lyricEntries.isEmpty()) "" else "Line Synced\nLyrics provided by LRCLIB",
+                style = MaterialTheme.typography.bodyMedium.copy(fontSize = 13.sp, fontWeight = FontWeight.Normal),
+                color = Color.White.copy(alpha = 0.68f),
+                modifier = Modifier.align(Alignment.End),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SpotifyArtistCard(
+    artist: String,
+    artistId: String? = null,
+    thumbnailUrl: String?,
+    onClick: () -> Unit,
+) {
+    val database = LocalDatabase.current
+    val avatarUrl by produceState<String?>(initialValue = thumbnailUrl, key1 = artistId, key2 = thumbnailUrl) {
+        if (!artistId.isNullOrBlank()) {
+            val dbArtist = withContext(Dispatchers.IO) { database.artist(artistId).firstOrNull() }
+            if (!dbArtist?.artist?.thumbnailUrl.isNullOrBlank()) {
+                value = dbArtist?.artist?.thumbnailUrl
+            } else {
+                withContext(Dispatchers.IO) {
+                    YouTube.artist(artistId).onSuccess { artistPage ->
+                        artistPage.artist.thumbnail?.let { url ->
+                            value = url
+                            dbArtist?.artist?.let { entity ->
+                                database.query {
+                                    update(entity.copy(thumbnailUrl = url))
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(250.dp)
+            .clip(RoundedCornerShape(8.dp))
+            .clickable(onClick = onClick),
+    ) {
+        AsyncImage(
+            model = avatarUrl ?: thumbnailUrl,
+            contentDescription = null,
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize().alpha(0.82f),
+        )
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        listOf(Color.Black.copy(alpha = 0.1f), Color.Black.copy(alpha = 0.66f))
+                    )
+                )
+        )
+        Text(
+            text = androidx.compose.ui.res.stringResource(R.string.artists),
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.ExtraBold,
+            color = Color.White,
+            modifier = Modifier.align(Alignment.TopStart).padding(28.dp),
+        )
+        Column(
+            modifier = Modifier.align(Alignment.BottomStart).padding(28.dp),
+        ) {
+            Text(
+                text = artist,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.ExtraBold,
+                color = Color.White,
+            )
+            Text(
+                text = "Artist",
+                style = MaterialTheme.typography.titleMedium,
+                color = Color.White.copy(alpha = 0.7f),
+            )
+        }
+    }
+}
+
+@Composable
+private fun SpotifyDetailsCard(
+    mediaMetadata: MediaMetadata,
+    artists: String,
+    surfaceColor: Color,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(8.dp))
+            .background(surfaceColor.copy(alpha = 0.9f))
+            .clickable(onClick = onClick)
+            .padding(28.dp),
+    ) {
+        Column {
+            Text(
+                text = mediaMetadata.album?.title?.takeIf { it.isNotBlank() } ?: mediaMetadata.title,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.ExtraBold,
+                color = Color.White,
+            )
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = makeTimeString(mediaMetadata.duration * 1000L),
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.ExtraBold,
+                color = Color.White,
+            )
+            Spacer(Modifier.height(16.dp))
+            Text(
+                text = artists,
+                style = MaterialTheme.typography.titleMedium,
+                fontWeight = FontWeight.Bold,
+                color = Color.White.copy(alpha = 0.62f),
+            )
+            Spacer(Modifier.height(22.dp))
+            Text(
+                text = "Description",
+                style = MaterialTheme.typography.headlineSmall.copy(fontSize = 20.sp, fontWeight = FontWeight.Bold),
+                color = Color.White,
+            )
+            Spacer(Modifier.height(12.dp))
+            Text(
+                text = listOf(mediaMetadata.title, artists).joinToString(" • "),
+                style = MaterialTheme.typography.titleMedium,
+                color = Color.White.copy(alpha = 0.62f),
+            )
+            Spacer(Modifier.height(18.dp))
+            Text(
+                text = "More",
+                style = MaterialTheme.typography.headlineSmall.copy(fontSize = 20.sp, fontWeight = FontWeight.Bold),
+                color = Color.White,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SpotifyRoundIconButton(
+    icon: Int,
+    transparent: Boolean = false,
+    tint: Color = Color.White,
+    onClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(42.dp)
+            .clip(CircleShape)
+            .background(if (transparent) Color.Transparent else Color.White.copy(alpha = 0.12f))
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Image(
+            painter = painterResource(icon),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(tint),
+            modifier = Modifier.size(23.dp)
+        )
+    }
+}
+
+@Composable
+private fun SpotifyPlainIconButton(
+    icon: Int,
+    onClick: () -> Unit,
+    tint: Color,
+) {
+    Box(
+        modifier = Modifier
+            .size(48.dp)
+            .clip(CircleShape)
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Image(
+            painter = painterResource(icon),
+            contentDescription = null,
+            colorFilter = ColorFilter.tint(tint),
+            modifier = Modifier.size(30.dp)
         )
     }
 }

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/player/Queue.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/player/Queue.kt
@@ -412,6 +412,10 @@ fun Queue(
                         onExpandQueue = { state.expandSoft() },
                     )
                 }
+
+                PlayerDesignStyle.SPOTIFY -> {
+                    // Spotify style uses its own inline action buttons
+                }
             }
 
             if (showSleepTimerDialog) {

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/player/Thumbnail.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/player/Thumbnail.kt
@@ -298,6 +298,7 @@ fun Thumbnail(
         PlayerBackgroundStyle.GLOW -> Color.White
         PlayerBackgroundStyle.GLOW_ANIMATED -> Color.White
         PlayerBackgroundStyle.CUSTOM -> Color.White
+        PlayerBackgroundStyle.SPOTIFY -> Color.White
     }
 
     LaunchedEffect(maxCanvasCacheSize) {

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/AppearanceSettings.kt
@@ -453,6 +453,7 @@ fun AppearanceSettings(
                     PlayerDesignStyle.V6 -> stringResource(R.string.player_design_v6)
                     PlayerDesignStyle.V7 -> stringResource(R.string.player_design_v7)
                     PlayerDesignStyle.V8 -> stringResource(R.string.Apple_Music)
+                    PlayerDesignStyle.SPOTIFY -> stringResource(R.string.player_design_spotify)
                 }
             },
         )

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/AppearanceSettings.kt
@@ -488,6 +488,7 @@ fun AppearanceSettings(
                     PlayerBackgroundStyle.BLUR_GRADIENT -> stringResource(R.string.blur_gradient)
                     PlayerBackgroundStyle.GLOW -> stringResource(R.string.glow)
                     PlayerBackgroundStyle.GLOW_ANIMATED -> "Glow Animated"
+                    PlayerBackgroundStyle.SPOTIFY -> stringResource(R.string.player_background_spotify)
                 }
             },
         )

--- a/app/src/main/res/values/opentune_strings.xml
+++ b/app/src/main/res/values/opentune_strings.xml
@@ -111,6 +111,7 @@
     <string name="player_design_v4">Cinematic</string>
     <string name="player_design_v5">Little</string>
     <string name="player_design_v6">Expressive</string>
+    <string name="player_design_spotify">Spotify</string>
     <string name="new_mini_player_design">New mini player design</string>
     <string name="player_background_blur">Blur</string>
     <string name="coloring">Coloring</string>

--- a/app/src/main/res/values/opentune_strings.xml
+++ b/app/src/main/res/values/opentune_strings.xml
@@ -117,6 +117,7 @@
     <string name="coloring">Coloring</string>
     <string name="blur_gradient">Blur Gradient</string>
     <string name="glow">Glow</string>
+    <string name="player_background_spotify">Spotify Blur</string>
     <string name="player_buttons_style">Player button colors</string>
     <string name="default_style">Default</string>
     <string name="secondary_color_style">Secondary</string>


### PR DESCRIPTION
## Summary of Changes

This PR introduces a brand-new **Spotify Player Design Style** and **Spotify Blur Background Option** to OpenTune, ported and adapted from AirBeats with full Jetpack Compose integration, dynamic artwork color palette extraction, live synced lyrics preview, interactive artist navigation, and responsive design support.

---

### Features & Highlights

1. **New Spotify Player Design Style (`PlayerDesignStyle.SPOTIFY`)**
   - Added `SPOTIFY` enum value to `PlayerDesignStyle` and mapped it in `AppearanceSettings` and `opentune_strings.xml`.
   - Users can now select the Spotify player style in **Settings > Appearance > Player Design Style**.

2. **Animated Sticky Header Bar (`SpotifyCollapsedHeader`)**
   - Added a smooth sticky top header bar containing track title, artist name, collapse action, and quick song menu.
   - Automatically animates into view when scrolling down the player sheet (`spotifyScrollState > 400px`).

3. **Live Synced Lyrics Preview Card (`SpotifyLyricsPreviewCard`)**
   - Connected `currentLyrics` flow from `PlayerConnection` to preview live synced lyrics matching the current playback position.
   - Tapping the card seamlessly opens the full synced lyrics sheet.

4. **Dynamic Ambient Artwork Glow & New Background Option (`PlayerBackgroundStyle.SPOTIFY`)**
   - Integrated dynamic color extraction via `Palette` from album cover thumbnails.
   - Added **Spotify Blur** to **Settings > Appearance > Player Background Style**, allowing users to apply the signature Spotify blurred dynamic gradient backdrop to any player style.

5. **Interactive Clickable Artist Navigation**
   - Made artist names under the song title (in both main Spotify player content and sticky top header) interactive.
   - Tapping any artist's name navigates directly to that artist's page and collapses the player sheet.

6. **Dynamic Artist Avatars (`SpotifyArtistCard`)**
   - Automatically resolves artist profile images using database mapping and live YouTube Music artist queries (`YouTube.artist(artistId)`).
   - Displays real artist profile photos instead of fallback track thumbnails.

7. **Customizable Player Sliders (`SpotifyStyledSlider`)**
   - Delegated to `StyledPlaybackSlider` so the Spotify player respects all user-selected slider styles under **Settings > Appearance > Player Slider Style** (`Standard`, `Wavy`, `Thick`, `Circular`, `Simple`).

8. **Clean Action Bar Scoping**
   - Hidden non-Spotify bottom bar action items for the Spotify style while preserving them for Apple Music (V8) and all other player styles.

---

### Verification & Testing

- ✅ Built and verified with `./gradlew assembleArm64Debug`: **BUILD SUCCESSFUL**
- ✅ Tested sticky header animations during scrolling.
- ✅ Verified live synced lyrics preview.
- ✅ Verified interactive artist navigation to artist page on click.
- ✅ Confirmed Spotify Blur background style option in Appearance Settings.
- ✅ Confirmed dynamic artist avatar resolution.
- ✅ Confirmed all custom player slider styles work correctly.
- ✅ Tested on both a physical ARM64 device and emulator.

---

### Preview

<p align="center">
  <img src="https://github.com/user-attachments/assets/3b08e26c-521f-4fb2-8752-7324a771fb8f" width="260"/>
  <img src="https://github.com/user-attachments/assets/2f73a30e-8fd3-4360-a78f-99efe3451f22" width="260"/>
  <img src="https://github.com/user-attachments/assets/93317d40-20fc-40dd-8563-9d9f652c1b4b" width="260"/>
</p>