### PR TITLE
Add on-device local music playback support

### DIFF
--- a/app/schemas/com.arturo254.opentune.db.InternalDatabase/28.json
+++ b/app/schemas/com.arturo254.opentune.db.InternalDatabase/28.json
@@ -1,0 +1,1084 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 28,
+    "identityHash": "e6f386216e8bab8f394754c48b84a5d1",
+    "entities": [
+      {
+        "tableName": "song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `duration` INTEGER NOT NULL, `thumbnailUrl` TEXT, `albumId` TEXT, `albumName` TEXT, `explicit` INTEGER NOT NULL DEFAULT 0, `year` INTEGER, `date` INTEGER, `dateModified` INTEGER, `liked` INTEGER NOT NULL, `likedDate` INTEGER, `totalPlayTime` INTEGER NOT NULL, `inLibrary` INTEGER, `dateDownload` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT 0, `localPath` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albumName",
+            "columnName": "albumName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateModified",
+            "columnName": "dateModified",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "liked",
+            "columnName": "liked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "totalPlayTime",
+            "columnName": "totalPlayTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "dateDownload",
+            "columnName": "dateDownload",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "localPath",
+            "columnName": "localPath",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "artist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `thumbnailUrl` TEXT, `channelId` TEXT, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "album",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `playlistId` TEXT, `title` TEXT NOT NULL, `year` INTEGER, `thumbnailUrl` TEXT, `themeColor` INTEGER, `songCount` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `explicit` INTEGER NOT NULL DEFAULT 0, `lastUpdateTime` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `likedDate` INTEGER, `inLibrary` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "themeColor",
+            "columnName": "themeColor",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "songCount",
+            "columnName": "songCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "explicit",
+            "columnName": "explicit",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "likedDate",
+            "columnName": "likedDate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "inLibrary",
+            "columnName": "inLibrary",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `browseId` TEXT, `createdAt` INTEGER, `lastUpdateTime` INTEGER, `isEditable` INTEGER NOT NULL DEFAULT true, `bookmarkedAt` INTEGER, `remoteSongCount` INTEGER, `playEndpointParams` TEXT, `thumbnailUrl` TEXT, `shuffleEndpointParams` TEXT, `radioEndpointParams` TEXT, `customOrder` INTEGER, `isLocal` INTEGER NOT NULL DEFAULT 0, `isAutoSync` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browseId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastUpdateTime",
+            "columnName": "lastUpdateTime",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isEditable",
+            "columnName": "isEditable",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "remoteSongCount",
+            "columnName": "remoteSongCount",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playEndpointParams",
+            "columnName": "playEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shuffleEndpointParams",
+            "columnName": "shuffleEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "radioEndpointParams",
+            "columnName": "radioEndpointParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "customOrder",
+            "columnName": "customOrder",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "isAutoSync",
+            "columnName": "isAutoSync",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "song_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `position` INTEGER NOT NULL, PRIMARY KEY(`songId`, `artistId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_artist_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "song_album_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `albumId` TEXT NOT NULL, `index` INTEGER NOT NULL, PRIMARY KEY(`songId`, `albumId`), FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "index",
+            "columnName": "index",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "albumId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_song_album_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_song_album_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_song_album_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "album_artist_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`albumId` TEXT NOT NULL, `artistId` TEXT NOT NULL, `order` INTEGER NOT NULL, PRIMARY KEY(`albumId`, `artistId`), FOREIGN KEY(`albumId`) REFERENCES `album`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`artistId`) REFERENCES `artist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "albumId",
+            "columnName": "albumId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "albumId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_album_artist_map_albumId",
+            "unique": false,
+            "columnNames": [
+              "albumId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_albumId` ON `${TABLE_NAME}` (`albumId`)"
+          },
+          {
+            "name": "index_album_artist_map_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_album_artist_map_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "album",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "albumId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "artist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "artistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `playlistId` TEXT NOT NULL, `songId` TEXT NOT NULL, `position` INTEGER NOT NULL, `setVideoId` TEXT, FOREIGN KEY(`playlistId`) REFERENCES `playlist`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_song_map_playlistId",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+          },
+          {
+            "name": "index_playlist_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlist",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "search_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `query` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_search_history_query",
+            "unique": true,
+            "columnNames": [
+              "query"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_search_history_query` ON `${TABLE_NAME}` (`query`)"
+          }
+        ]
+      },
+      {
+        "tableName": "format",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `itag` INTEGER NOT NULL, `mimeType` TEXT NOT NULL, `codecs` TEXT NOT NULL, `bitrate` INTEGER NOT NULL, `sampleRate` INTEGER, `contentLength` INTEGER NOT NULL, `loudnessDb` REAL, `perceptualLoudnessDb` REAL, `playbackUrl` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "itag",
+            "columnName": "itag",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "codecs",
+            "columnName": "codecs",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bitrate",
+            "columnName": "bitrate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sampleRate",
+            "columnName": "sampleRate",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "contentLength",
+            "columnName": "contentLength",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "loudnessDb",
+            "columnName": "loudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "perceptualLoudnessDb",
+            "columnName": "perceptualLoudnessDb",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "playbackUrl",
+            "columnName": "playbackUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "lyrics",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `lyrics` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lyrics",
+            "columnName": "lyrics",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "event",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `playTime` INTEGER NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "playTime",
+            "columnName": "playTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_event_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_event_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "related_song_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `songId` TEXT NOT NULL, `relatedSongId` TEXT NOT NULL, FOREIGN KEY(`songId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`relatedSongId`) REFERENCES `song`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatedSongId",
+            "columnName": "relatedSongId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_related_song_map_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_songId` ON `${TABLE_NAME}` (`songId`)"
+          },
+          {
+            "name": "index_related_song_map_relatedSongId",
+            "unique": false,
+            "columnNames": [
+              "relatedSongId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_related_song_map_relatedSongId` ON `${TABLE_NAME}` (`relatedSongId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "songId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "song",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "relatedSongId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "set_video_id",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `setVideoId` TEXT, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "setVideoId",
+            "columnName": "setVideoId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "playCount",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song` TEXT NOT NULL, `year` INTEGER NOT NULL, `month` INTEGER NOT NULL, `count` INTEGER NOT NULL, PRIMARY KEY(`song`, `year`, `month`))",
+        "fields": [
+          {
+            "fieldPath": "song",
+            "columnName": "song",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "year",
+            "columnName": "year",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "month",
+            "columnName": "month",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "song",
+            "year",
+            "month"
+          ]
+        }
+      },
+      {
+        "tableName": "tag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `color` TEXT NOT NULL DEFAULT '#FF6B6B', `createdAt` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'#FF6B6B'"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlist_tag_map",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `tagId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY(`playlistId`, `tagId`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagId",
+            "columnName": "tagId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "CURRENT_TIMESTAMP"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "tagId"
+          ]
+        }
+      }
+    ],
+    "views": [
+      {
+        "viewName": "sorted_song_artist_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_artist_map ORDER BY position"
+      },
+      {
+        "viewName": "sorted_song_album_map",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM song_album_map ORDER BY `index`"
+      },
+      {
+        "viewName": "playlist_song_map_preview",
+        "createSql": "CREATE VIEW `${VIEW_NAME}` AS SELECT * FROM playlist_song_map WHERE position <= 3 ORDER BY position"
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'e6f386216e8bab8f394754c48b84a5d1')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -132,6 +132,24 @@
                 <data android:mimeType="text/plain" />
             </intent-filter>
 
+            <!-- Open local audio files from file managers ("Open with") -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:mimeType="audio/*" />
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+
+                <data android:mimeType="audio/*" />
+            </intent-filter>
+
             <meta-data
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />

--- a/app/src/main/kotlin/com/arturo254/opentune/MainActivity.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/MainActivity.kt
@@ -136,6 +136,7 @@ import androidx.compose.ui.util.fastFirstOrNull
 import androidx.compose.ui.util.fastForEach
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
+import android.net.Uri
 import androidx.core.net.toUri
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
@@ -209,6 +210,7 @@ import com.arturo254.opentune.innertube.models.ArtistItem
 import com.arturo254.opentune.innertube.models.PlaylistItem
 import com.arturo254.opentune.innertube.models.SongItem
 import com.arturo254.opentune.extensions.toMediaItem
+import com.arturo254.opentune.utils.LocalMediaScanner
 import com.arturo254.opentune.models.toMediaMetadata
 import com.arturo254.opentune.playback.DownloadUtil
 import com.arturo254.opentune.playback.MusicService
@@ -328,6 +330,39 @@ class MainActivity : ComponentActivity() {
     private data class PendingDeepLinkSong(
         val mediaItem: MediaItem,
     )
+
+    private fun playLocalAudioUri(uri: Uri) {
+        runCatching {
+            contentResolver.takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+
+        lifecycleScope.launch {
+            // Upsert into the library DB (like the "On Device" scanner does) rather than
+            // building a standalone MediaItem: now-playing state, the notification, the queue
+            // UI and duration are all driven off `database.song(mediaId)` lookups in
+            // MusicService, so an item that isn't in the DB shows up with no metadata at all.
+            val song = runCatching {
+                LocalMediaScanner.scanUri(this@MainActivity, database, uri)
+            }.getOrNull()
+
+            val mediaItem = song?.toMediaItem() ?: MediaItem
+                .Builder()
+                .setMediaId("LMOPEN${uri.hashCode()}")
+                .setUri(uri)
+                .setMediaMetadata(
+                    androidx.media3.common.MediaMetadata
+                        .Builder()
+                        .setTitle(uri.lastPathSegment ?: "Unknown")
+                        .setArtist("Unknown artist")
+                        .setMediaType(androidx.media3.common.MediaMetadata.MEDIA_TYPE_MUSIC)
+                        .build(),
+                ).build()
+
+            pendingDeepLinkSong = PendingDeepLinkSong(mediaItem = mediaItem)
+            startMusicServiceSafely()
+            playPendingDeepLinkSongIfReady()
+        }
+    }
 
     private fun playPendingDeepLinkSongIfReady() {
         val pending = pendingDeepLinkSong ?: return
@@ -1958,8 +1993,17 @@ class MainActivity : ComponentActivity() {
             return
         }
 
-        val uri = intent.data ?: intent.extras?.getString(Intent.EXTRA_TEXT)?.toUri() ?: return
+        val uri = intent.data
+            ?: (intent.extras?.get(Intent.EXTRA_STREAM) as? Uri)
+            ?: intent.extras?.getString(Intent.EXTRA_TEXT)?.toUri()
+            ?: return
         val coroutineScope = lifecycleScope
+
+        val mimeType = intent.type ?: contentResolver.getType(uri)
+        if ((uri.scheme == "content" || uri.scheme == "file") && mimeType?.startsWith("audio/") == true) {
+            playLocalAudioUri(uri)
+            return
+        }
 
         val authority = uri.authority?.lowercase()
         if (uri.scheme.equals("OpenTune", ignoreCase = true) && authority == "together") {

--- a/app/src/main/kotlin/com/arturo254/opentune/constants/LibraryFilter.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/constants/LibraryFilter.kt
@@ -14,5 +14,6 @@ enum class LibraryFilter {
     ALBUMS,
     PLAYLISTS,
     LIBRARY,
-    SPOTIFY
+    SPOTIFY,
+    ON_DEVICE
 }

--- a/app/src/main/kotlin/com/arturo254/opentune/db/DatabaseDao.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/db/DatabaseDao.kt
@@ -188,6 +188,10 @@ interface DatabaseDao {
     fun songsByPlayTimeAscNoVideo(): Flow<List<Song>>
 
     @Transaction
+    @Query("SELECT * FROM song WHERE isLocal ORDER BY title COLLATE NOCASE")
+    fun localSongs(): Flow<List<Song>>
+
+    @Transaction
     @Query("SELECT * FROM song WHERE liked ORDER BY rowId")
     fun likedSongsByRowIdAsc(): Flow<List<Song>>
 

--- a/app/src/main/kotlin/com/arturo254/opentune/db/MusicDatabase.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/db/MusicDatabase.kt
@@ -58,7 +58,7 @@ import java.util.concurrent.Executor
 import kotlin.coroutines.resume
 
 private const val TAG = "MusicDatabase"
-private const val CURRENT_VERSION = 27
+private const val CURRENT_VERSION = 28
 
 class MusicDatabase(
     private val delegate: InternalDatabase,
@@ -153,6 +153,7 @@ class MusicDatabase(
         AutoMigration(from = 19, to = 20, spec = Migration19To20::class),
         AutoMigration(from = 20, to = 21, spec = Migration20To21::class),
         AutoMigration(from = 21, to = 22),
+        AutoMigration(from = 27, to = 28),
     ],
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/kotlin/com/arturo254/opentune/db/entities/SongEntity.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/db/entities/SongEntity.kt
@@ -47,21 +47,28 @@ data class SongEntity(
     val inLibrary: LocalDateTime? = null,
     val dateDownload: LocalDateTime? = LocalDateTime.now(),
     @ColumnInfo(name = "isLocal", defaultValue = "0")
-    val isLocal: Boolean = false
+    val isLocal: Boolean = false,
+    @ColumnInfo(name = "localPath")
+    val localPath: String? = null
 ) {
     fun localToggleLike() = copy(
         liked = !liked,
         likedDate = if (!liked) LocalDateTime.now() else null,
     )
 
-    fun toggleLike() = copy(
-        liked = !liked,
-        likedDate = if (!liked) LocalDateTime.now() else null,
-        inLibrary = if (!liked) inLibrary ?: LocalDateTime.now() else inLibrary
-    ).also {
-        CoroutineScope(Dispatchers.IO).launch {
-            YouTube.likeVideo(id, !liked)
-            this.cancel()
+    fun toggleLike(): SongEntity {
+        // Local on-device songs have no YouTube video to like — just flip the flag.
+        if (isLocal) return localToggleLike()
+
+        return copy(
+            liked = !liked,
+            likedDate = if (!liked) LocalDateTime.now() else null,
+            inLibrary = if (!liked) inLibrary ?: LocalDateTime.now() else inLibrary
+        ).also {
+            CoroutineScope(Dispatchers.IO).launch {
+                YouTube.likeVideo(id, !liked)
+                this.cancel()
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/arturo254/opentune/extensions/MediaItemExt.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/extensions/MediaItemExt.kt
@@ -28,7 +28,7 @@ fun Song.toMediaItem() =
     MediaItem
         .Builder()
         .setMediaId(song.id)
-        .setUri(song.id)
+        .setUri(if (song.isLocal && song.localPath != null) song.localPath.toUri() else song.id.toUri())
         .setCustomCacheKey(song.id)
         .setTag(toMediaMetadata())
         .setMediaMetadata(

--- a/app/src/main/kotlin/com/arturo254/opentune/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/playback/MusicService.kt
@@ -4300,6 +4300,12 @@ class MusicService :
 
     private fun createDataSourceFactory(): DataSource.Factory {
         return ResolvingDataSource.Factory(createCacheDataSource()) { dataSpec ->
+            // Local on-device files already carry their real content:// URI (see
+            // Song.toMediaItem()) — skip YouTube stream resolution entirely for them.
+            if (dataSpec.uri.scheme == "content") {
+                return@Factory dataSpec
+            }
+
             val mediaId = dataSpec.key ?: error("No media id")
 
             val requiredCachedLength =

--- a/app/src/main/kotlin/com/arturo254/opentune/playback/MusicService.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/playback/MusicService.kt
@@ -69,6 +69,8 @@ import androidx.media3.exoplayer.audio.DefaultAudioSink
 import androidx.media3.exoplayer.audio.SilenceSkippingAudioProcessor
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import androidx.media3.exoplayer.source.ShuffleOrder.DefaultShuffleOrder
+import androidx.media3.extractor.DefaultExtractorsFactory
+import androidx.media3.extractor.Extractor
 import androidx.media3.extractor.ExtractorsFactory
 import androidx.media3.extractor.mkv.MatroskaExtractor
 import androidx.media3.extractor.mp4.FragmentedMp4Extractor
@@ -4302,7 +4304,7 @@ class MusicService :
         return ResolvingDataSource.Factory(createCacheDataSource()) { dataSpec ->
             // Local on-device files already carry their real content:// URI (see
             // Song.toMediaItem()) — skip YouTube stream resolution entirely for them.
-            if (dataSpec.uri.scheme == "content") {
+            if (dataSpec.uri.scheme == "content" || dataSpec.uri.scheme == "file") {
                 return@Factory dataSpec
             }
 
@@ -4598,8 +4600,23 @@ class MusicService :
     private fun createMediaSourceFactory() =
         DefaultMediaSourceFactory(
             createDataSourceFactory(),
-            ExtractorsFactory {
-                arrayOf(Mp4Extractor(), FragmentedMp4Extractor(), MatroskaExtractor())
+            object : ExtractorsFactory {
+                private val defaultExtractorsFactory = DefaultExtractorsFactory()
+
+                override fun createExtractors(): Array<Extractor> =
+                    arrayOf(Mp4Extractor(), FragmentedMp4Extractor(), MatroskaExtractor())
+
+                override fun createExtractors(
+                    uri: android.net.Uri,
+                    responseHeaders: MutableMap<String, MutableList<String>>,
+                ): Array<Extractor> =
+                    // Local on-device files can be mp3/flac/ogg/wav/etc, unlike YouTube's
+                    // mp4/webm streams, so fall back to the full set of extractors for them.
+                    if (uri.scheme == "content" || uri.scheme == "file") {
+                        defaultExtractorsFactory.createExtractors(uri, responseHeaders)
+                    } else {
+                        createExtractors()
+                    }
             },
         )
 

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/menu/PlayerMenu.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/menu/PlayerMenu.kt
@@ -151,6 +151,7 @@ fun ColumnScope.PlayerMenu(
     val activityResultLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.StartActivityForResult()) { }
     val librarySong by database.song(mediaMetadata.id).collectAsState(initial = null)
+    val isLocalSong = librarySong?.song?.isLocal == true
     val coroutineScope = rememberCoroutineScope()
 
     val download by LocalDownloadUtil.current.getDownload(mediaMetadata.id)
@@ -395,23 +396,28 @@ fun ColumnScope.PlayerMenu(
         // ── Acciones rápidas ─────────────────────────────────────────────────
         item {
             NewActionGrid(
-                actions = listOf(
-                    NewAction(
-                        icon = {
-                            Icon(
-                                painter = painterResource(R.drawable.radio),
-                                contentDescription = null,
-                                modifier = Modifier.size(28.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        },
-                        text = stringResource(R.string.start_radio),
-                        onClick = {
-                            Toast.makeText(context, context.getString(R.string.starting_radio), Toast.LENGTH_SHORT).show()
-                            playerConnection.startRadioSeamlessly()
-                            onDismiss()
-                        }
-                    ),
+                actions = listOfNotNull(
+                    // Radio and copying a YouTube Music link don't apply to on-device files.
+                    if (isLocalSong) {
+                        null
+                    } else {
+                        NewAction(
+                            icon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.radio),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(28.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            },
+                            text = stringResource(R.string.start_radio),
+                            onClick = {
+                                Toast.makeText(context, context.getString(R.string.starting_radio), Toast.LENGTH_SHORT).show()
+                                playerConnection.startRadioSeamlessly()
+                                onDismiss()
+                            }
+                        )
+                    },
                     NewAction(
                         icon = {
                             Icon(
@@ -449,27 +455,31 @@ fun ColumnScope.PlayerMenu(
                             onDismiss()
                         }
                     ),
-                    NewAction(
-                        icon = {
-                            Icon(
-                                painter = painterResource(R.drawable.link),
-                                contentDescription = null,
-                                modifier = Modifier.size(28.dp),
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
-                            )
-                        },
-                        text = stringResource(R.string.copy_link),
-                        onClick = {
-                            val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
-                            val clip = android.content.ClipData.newPlainText(
-                                context.getString(R.string.copy_link),
-                                "https://music.youtube.com/watch?v=${mediaMetadata.id}",
-                            )
-                            clipboard.setPrimaryClip(clip)
-                            android.widget.Toast.makeText(context, R.string.link_copied, android.widget.Toast.LENGTH_SHORT).show()
-                            onDismiss()
-                        }
-                    ),
+                    if (isLocalSong) {
+                        null
+                    } else {
+                        NewAction(
+                            icon = {
+                                Icon(
+                                    painter = painterResource(R.drawable.link),
+                                    contentDescription = null,
+                                    modifier = Modifier.size(28.dp),
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            },
+                            text = stringResource(R.string.copy_link),
+                            onClick = {
+                                val clipboard = context.getSystemService(android.content.Context.CLIPBOARD_SERVICE) as android.content.ClipboardManager
+                                val clip = android.content.ClipData.newPlainText(
+                                    context.getString(R.string.copy_link),
+                                    "https://music.youtube.com/watch?v=${mediaMetadata.id}",
+                                )
+                                clipboard.setPrimaryClip(clip)
+                                android.widget.Toast.makeText(context, R.string.link_copied, android.widget.Toast.LENGTH_SHORT).show()
+                                onDismiss()
+                            }
+                        )
+                    },
                     NewAction(
                         icon = {
                             Icon(
@@ -513,7 +523,7 @@ fun ColumnScope.PlayerMenu(
         item { Spacer(modifier = Modifier.height(12.dp)) }
 
         // ── Artista / Álbum ──────────────────────────────────────────────────
-        if (splitArtists.isNotEmpty() || mediaMetadata.album != null) {
+        if (!isLocalSong && (splitArtists.isNotEmpty() || mediaMetadata.album != null)) {
             item {
                 MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
                     Column {
@@ -564,6 +574,8 @@ fun ColumnScope.PlayerMenu(
         }
 
         // ── Descarga ─────────────────────────────────────────────────────────
+        // Downloading a copy of a file that's already on-device is meaningless.
+        if (!isLocalSong) {
         item {
             MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
                 when (download?.state) {
@@ -639,11 +651,15 @@ fun ColumnScope.PlayerMenu(
                 }
             }
         }
+        }
 
         // ── Detalles / Ecualizador / Tempo ───────────────────────────────────
         item {
             MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
                 Column {
+                    // Format/codec details come from the YouTube stream response and don't
+                    // exist for a local file.
+                    if (!isLocalSong) {
                     ListItem(
                         headlineContent = { Text(text = stringResource(R.string.details)) },
                         leadingContent = { Icon(painter = painterResource(R.drawable.info), contentDescription = null) },
@@ -653,6 +669,7 @@ fun ColumnScope.PlayerMenu(
                         },
                         colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                     )
+                    }
 
                     if (isQueueTrigger != true) {
                         HorizontalDivider(modifier = Modifier.padding(start = 56.dp), color = MaterialTheme.colorScheme.outlineVariant)

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/menu/SongMenu.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/menu/SongMenu.kt
@@ -396,22 +396,27 @@ fun SongMenu(
         onDismiss,
         playerConnection,
     ) {
-        listOf(
-            NewAction(
-                icon = {
-                    Icon(
-                        painter = painterResource(R.drawable.radio),
-                        contentDescription = null,
-                        modifier = Modifier.size(28.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                },
-                text = startRadioText,
-                onClick = {
-                    onDismiss()
-                    playerConnection.playQueue(YouTubeQueue.radio(song.toMediaMetadata()))
-                },
-            ),
+        listOfNotNull(
+            // Radio and sharing a YouTube Music link are meaningless for on-device files.
+            if (song.song.isLocal) {
+                null
+            } else {
+                NewAction(
+                    icon = {
+                        Icon(
+                            painter = painterResource(R.drawable.radio),
+                            contentDescription = null,
+                            modifier = Modifier.size(28.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    text = startRadioText,
+                    onClick = {
+                        onDismiss()
+                        playerConnection.playQueue(YouTubeQueue.radio(song.toMediaMetadata()))
+                    },
+                )
+            },
             NewAction(
                 icon = {
                     Icon(
@@ -454,27 +459,31 @@ fun SongMenu(
                 text = addToPlaylistText,
                 onClick = { showChoosePlaylistDialog = true },
             ),
-            NewAction(
-                icon = {
-                    Icon(
-                        painter = painterResource(R.drawable.share),
-                        contentDescription = null,
-                        modifier = Modifier.size(28.dp),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                    )
-                },
-                text = shareText,
-                onClick = {
-                    onDismiss()
-                    val intent =
-                        Intent().apply {
-                            action = Intent.ACTION_SEND
-                            type = "text/plain"
-                            putExtra(Intent.EXTRA_TEXT, "https://music.youtube.com/watch?v=${song.id}")
-                        }
-                    context.startActivity(Intent.createChooser(intent, null))
-                },
-            ),
+            if (song.song.isLocal) {
+                null
+            } else {
+                NewAction(
+                    icon = {
+                        Icon(
+                            painter = painterResource(R.drawable.share),
+                            contentDescription = null,
+                            modifier = Modifier.size(28.dp),
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                        )
+                    },
+                    text = shareText,
+                    onClick = {
+                        onDismiss()
+                        val intent =
+                            Intent().apply {
+                                action = Intent.ACTION_SEND
+                                type = "text/plain"
+                                putExtra(Intent.EXTRA_TEXT, "https://music.youtube.com/watch?v=${song.id}")
+                            }
+                        context.startActivity(Intent.createChooser(intent, null))
+                    },
+                )
+            },
             NewAction(
                 icon = {
                     Icon(
@@ -585,15 +594,16 @@ fun SongMenu(
             }
         }
 
-        item {
-            Spacer(modifier = Modifier.height(12.dp))
-        }
+        if (event != null || playlistSong != null || !song.song.isLocal) {
+            item {
+                Spacer(modifier = Modifier.height(12.dp))
+            }
 
-        item {
-            MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
-                val dividerModifier = Modifier.padding(start = 56.dp)
-                Column {
-                    if (event != null) {
+            item {
+                MenuSurfaceSection(modifier = Modifier.padding(vertical = 6.dp)) {
+                    val dividerModifier = Modifier.padding(start = 56.dp)
+                    Column {
+                        if (event != null) {
                         ListItem(
                             headlineContent = {
                                 Text(
@@ -673,150 +683,156 @@ fun SongMenu(
                         )
                     }
 
-                    if (isFromCache) {
-                        ListItem(
-                            headlineContent = {
-                                Text(
-                                    text = stringResource(R.string.remove_from_cache),
-                                    color = MaterialTheme.colorScheme.error,
-                                )
-                            },
-                            leadingContent = {
-                                Icon(
-                                    painter = painterResource(R.drawable.delete),
-                                    tint = MaterialTheme.colorScheme.error,
-                                    contentDescription = null,
-                                )
-                            },
-                            modifier =
-                                Modifier.clickable {
-                                    onDismiss()
-                                    cacheViewModel.removeSongFromCache(song.id)
-                                },
-                            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                        )
-
-                        HorizontalDivider(
-                            modifier = dividerModifier,
-                            color = MaterialTheme.colorScheme.outlineVariant,
-                        )
-                    }
-
-                    when (downloadState) {
-                        Download.STATE_COMPLETED -> {
+                    // Caching/downloading a copy of a file that's already on-device is meaningless.
+                    if (!song.song.isLocal) {
+                        if (isFromCache) {
                             ListItem(
                                 headlineContent = {
                                     Text(
-                                        text = stringResource(R.string.remove_download),
+                                        text = stringResource(R.string.remove_from_cache),
                                         color = MaterialTheme.colorScheme.error,
                                     )
                                 },
                                 leadingContent = {
                                     Icon(
-                                        painter = painterResource(R.drawable.offline),
+                                        painter = painterResource(R.drawable.delete),
                                         tint = MaterialTheme.colorScheme.error,
                                         contentDescription = null,
                                     )
                                 },
                                 modifier =
                                     Modifier.clickable {
-                                        DownloadService.sendRemoveDownload(
-                                            context,
-                                            ExoDownloadService::class.java,
-                                            song.id,
-                                            false,
-                                        )
+                                        onDismiss()
+                                        cacheViewModel.removeSongFromCache(song.id)
                                     },
                                 colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                             )
-                        }
-                        Download.STATE_QUEUED, Download.STATE_DOWNLOADING -> {
-                            ListItem(
-                                headlineContent = { Text(text = stringResource(R.string.downloading)) },
-                                leadingContent = {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier.size(24.dp),
-                                        strokeWidth = 2.dp,
-                                    )
-                                },
-                                modifier =
-                                    Modifier.clickable {
-                                        DownloadService.sendRemoveDownload(
-                                            context,
-                                            ExoDownloadService::class.java,
-                                            song.id,
-                                            false,
-                                        )
-                                    },
-                                colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+
+                            HorizontalDivider(
+                                modifier = dividerModifier,
+                                color = MaterialTheme.colorScheme.outlineVariant,
                             )
                         }
-                        else -> {
+
+                        when (downloadState) {
+                            Download.STATE_COMPLETED -> {
+                                ListItem(
+                                    headlineContent = {
+                                        Text(
+                                            text = stringResource(R.string.remove_download),
+                                            color = MaterialTheme.colorScheme.error,
+                                        )
+                                    },
+                                    leadingContent = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.offline),
+                                            tint = MaterialTheme.colorScheme.error,
+                                            contentDescription = null,
+                                        )
+                                    },
+                                    modifier =
+                                        Modifier.clickable {
+                                            DownloadService.sendRemoveDownload(
+                                                context,
+                                                ExoDownloadService::class.java,
+                                                song.id,
+                                                false,
+                                            )
+                                        },
+                                    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                                )
+                            }
+                            Download.STATE_QUEUED, Download.STATE_DOWNLOADING -> {
+                                ListItem(
+                                    headlineContent = { Text(text = stringResource(R.string.downloading)) },
+                                    leadingContent = {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier.size(24.dp),
+                                            strokeWidth = 2.dp,
+                                        )
+                                    },
+                                    modifier =
+                                        Modifier.clickable {
+                                            DownloadService.sendRemoveDownload(
+                                                context,
+                                                ExoDownloadService::class.java,
+                                                song.id,
+                                                false,
+                                            )
+                                        },
+                                    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                                )
+                            }
+                            else -> {
+                                ListItem(
+                                    headlineContent = { Text(text = stringResource(R.string.action_download)) },
+                                    leadingContent = {
+                                        Icon(
+                                            painter = painterResource(R.drawable.download),
+                                            contentDescription = null,
+                                        )
+                                    },
+                                    modifier =
+                                        Modifier.clickable {
+                                            val downloadRequest =
+                                                DownloadRequest
+                                                    .Builder(song.id, song.id.toUri())
+                                                    .setCustomCacheKey(song.id)
+                                                    .setData(song.song.title.toByteArray())
+                                                    .build()
+                                            DownloadService.sendAddDownload(
+                                                context,
+                                                ExoDownloadService::class.java,
+                                                downloadRequest,
+                                                false,
+                                            )
+                                        },
+                                    colors = ListItemDefaults.colors(containerColor = Color.Transparent),
+                                )
+                            }
+                        }
+                        if (externalDownloaderEnabled) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(start = 56.dp),
+                                color = MaterialTheme.colorScheme.outlineVariant,
+                            )
                             ListItem(
-                                headlineContent = { Text(text = stringResource(R.string.action_download)) },
+                                headlineContent = { Text(text = stringResource(R.string.open_with_downloader)) },
                                 leadingContent = {
                                     Icon(
                                         painter = painterResource(R.drawable.download),
                                         contentDescription = null,
                                     )
                                 },
-                                modifier =
-                                    Modifier.clickable {
-                                        val downloadRequest =
-                                            DownloadRequest
-                                                .Builder(song.id, song.id.toUri())
-                                                .setCustomCacheKey(song.id)
-                                                .setData(song.song.title.toByteArray())
-                                                .build()
-                                        DownloadService.sendAddDownload(
-                                            context,
-                                            ExoDownloadService::class.java,
-                                            downloadRequest,
-                                            false,
-                                        )
-                                    },
+                                modifier = Modifier.clickable {
+                                    onDismiss()
+                                    val url = "https://music.youtube.com/watch?v=${song.id}"
+                                    if (externalDownloaderPackage.isBlank()) {
+                                        Toast.makeText(context, context.getString(R.string.external_downloader_not_configured), Toast.LENGTH_LONG).show()
+                                        return@clickable
+                                    }
+                                    val intent = android.content.Intent(android.content.Intent.ACTION_VIEW).apply {
+                                        setPackage(externalDownloaderPackage)
+                                        data = android.net.Uri.parse(url)
+                                        addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
+                                    }
+                                    try {
+                                        context.startActivity(intent)
+                                    } catch (e: android.content.ActivityNotFoundException) {
+                                        Toast.makeText(context, context.getString(R.string.external_downloader_not_installed), Toast.LENGTH_SHORT).show()
+                                    }
+                                },
                                 colors = ListItemDefaults.colors(containerColor = Color.Transparent),
                             )
                         }
                     }
-                    if (externalDownloaderEnabled) {
-                        HorizontalDivider(
-                            modifier = Modifier.padding(start = 56.dp),
-                            color = MaterialTheme.colorScheme.outlineVariant,
-                        )
-                        ListItem(
-                            headlineContent = { Text(text = stringResource(R.string.open_with_downloader)) },
-                            leadingContent = {
-                                Icon(
-                                    painter = painterResource(R.drawable.download),
-                                    contentDescription = null,
-                                )
-                            },
-                            modifier = Modifier.clickable {
-                                onDismiss()
-                                val url = "https://music.youtube.com/watch?v=${song.id}"
-                                if (externalDownloaderPackage.isBlank()) {
-                                    Toast.makeText(context, context.getString(R.string.external_downloader_not_configured), Toast.LENGTH_LONG).show()
-                                    return@clickable
-                                }
-                                val intent = android.content.Intent(android.content.Intent.ACTION_VIEW).apply {
-                                    setPackage(externalDownloaderPackage)
-                                    data = android.net.Uri.parse(url)
-                                    addFlags(android.content.Intent.FLAG_ACTIVITY_NEW_TASK)
-                                }
-                                try {
-                                    context.startActivity(intent)
-                                } catch (e: android.content.ActivityNotFoundException) {
-                                    Toast.makeText(context, context.getString(R.string.external_downloader_not_installed), Toast.LENGTH_SHORT).show()
-                                }
-                            },
-                            colors = ListItemDefaults.colors(containerColor = Color.Transparent),
-                        )
-                    }
                 }
             }
         }
+        }
 
+        // Browsing a YouTube-style artist/album page doesn't apply to on-device files.
+        if (!song.song.isLocal) {
         item {
             Spacer(modifier = Modifier.height(12.dp))
         }
@@ -869,7 +885,10 @@ fun SongMenu(
                 }
             }
         }
+        }
 
+        // Refetching from YouTube and showing stream/codec details don't apply to a local file.
+        if (!song.song.isLocal) {
         item {
             Spacer(modifier = Modifier.height(12.dp))
         }
@@ -927,6 +946,7 @@ fun SongMenu(
                     )
                 }
             }
+        }
         }
     }
 }

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/player/PlayerComponents.kt
@@ -252,7 +252,8 @@ fun PlayerTopActions(
     state: BottomSheetState,
     bottomSheetPageState: BottomSheetPageState,
     context: Context,
-    currentSongLiked: Boolean
+    currentSongLiked: Boolean,
+    isLocalSong: Boolean = false
 ) {
     when (playerDesignStyle) {
         PlayerDesignStyle.V2 -> {
@@ -270,6 +271,7 @@ fun PlayerTopActions(
                 horizontalArrangement = Arrangement.spacedBy(12.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                if (!isLocalSong) {
                 Box(
                     modifier = Modifier
                         .size(42.dp)
@@ -295,6 +297,7 @@ fun PlayerTopActions(
                             .align(Alignment.Center)
                             .size(24.dp)
                     )
+                }
                 }
 
                 Box(
@@ -327,6 +330,7 @@ fun PlayerTopActions(
                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                if (!isLocalSong) {
                 Box(
                     modifier = Modifier
                         .size(36.dp)
@@ -350,6 +354,7 @@ fun PlayerTopActions(
                         tint = textBackgroundColor.copy(alpha = 0.7f),
                         modifier = Modifier.size(20.dp)
                     )
+                }
                 }
                 Box(
                     modifier = Modifier
@@ -378,6 +383,7 @@ fun PlayerTopActions(
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                if (!isLocalSong) {
                 Surface(
                     onClick = {
                         val intent = Intent().apply {
@@ -404,6 +410,7 @@ fun PlayerTopActions(
                             modifier = Modifier.size(22.dp)
                         )
                     }
+                }
                 }
 
                 Surface(
@@ -469,6 +476,7 @@ fun PlayerTopActions(
         }
 
         PlayerDesignStyle.V1 -> {
+            if (!isLocalSong) {
             Box(
                 modifier =
                     Modifier
@@ -497,6 +505,7 @@ fun PlayerTopActions(
                             .align(Alignment.Center)
                             .size(24.dp),
                 )
+            }
             }
 
             Spacer(modifier = Modifier.size(12.dp))
@@ -539,6 +548,7 @@ fun PlayerTopActions(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                if (!isLocalSong) {
                 Surface(
                     onClick = {
                         val intent = Intent().apply {
@@ -568,6 +578,7 @@ fun PlayerTopActions(
                             modifier = Modifier.size(20.dp)
                         )
                     }
+                }
                 }
 
                 Surface(
@@ -2195,7 +2206,8 @@ fun PlayerControlsContent(
             state = state,
             bottomSheetPageState = bottomSheetPageState,
             context = context,
-            currentSongLiked = currentSongLiked
+            currentSongLiked = currentSongLiked,
+            isLocalSong = currentSong?.song?.isLocal == true
         )
     }
 

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/library/LibraryScreen.kt
@@ -63,7 +63,8 @@ fun LibraryScreen(navController: NavController) {
                         LibraryFilter.SONGS to stringResource(R.string.filter_songs),
                         LibraryFilter.ALBUMS to stringResource(R.string.filter_albums),
                         LibraryFilter.ARTISTS to stringResource(R.string.filter_artists),
-                        LibraryFilter.SPOTIFY to stringResource(R.string.spotify)
+                        LibraryFilter.SPOTIFY to stringResource(R.string.spotify),
+                        LibraryFilter.ON_DEVICE to stringResource(R.string.filter_on_device)
                     ),
                     currentValue = filterType,
                     onValueUpdate = {
@@ -79,7 +80,8 @@ fun LibraryScreen(navController: NavController) {
                         LibraryFilter.SONGS to R.drawable.music_note,
                         LibraryFilter.ALBUMS to R.drawable.album,
                         LibraryFilter.ARTISTS to R.drawable.person,
-                        LibraryFilter.SPOTIFY to R.drawable.spotify_icon
+                        LibraryFilter.SPOTIFY to R.drawable.spotify_icon,
+                        LibraryFilter.ON_DEVICE to R.drawable.folder
                     ),
                     modifier = Modifier.weight(1f),
                 )
@@ -246,6 +248,11 @@ fun LibraryScreen(navController: NavController) {
                     filterContent = filterContent
                 )
             }
+
+            LibraryFilter.ON_DEVICE -> LocalSongsScreen(
+                navController,
+                { filterType = LibraryFilter.LIBRARY }
+            )
         }
     }
 }

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/library/LocalSongsScreen.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/library/LocalSongsScreen.kt
@@ -1,0 +1,278 @@
+/*
+ * OpenTune Project Original (2026)
+ * Arturo254 (github.com/Arturo254)
+ * Licensed Under GPL-3.0 | see git history for contributors
+ */
+
+
+
+package com.arturo254.opentune.ui.screens.library
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.asPaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.pullToRefresh
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.navigation.NavController
+import com.arturo254.opentune.LocalDatabase
+import com.arturo254.opentune.LocalPlayerAwareWindowInsets
+import com.arturo254.opentune.LocalPlayerConnection
+import com.arturo254.opentune.R
+import com.arturo254.opentune.constants.CONTENT_TYPE_HEADER
+import com.arturo254.opentune.constants.CONTENT_TYPE_SONG
+import com.arturo254.opentune.extensions.toMediaItem
+import com.arturo254.opentune.extensions.togglePlayPause
+import com.arturo254.opentune.playback.queues.ListQueue
+import com.arturo254.opentune.ui.component.LocalMenuState
+import com.arturo254.opentune.ui.component.SongListItem
+import com.arturo254.opentune.ui.menu.SongMenu
+import com.arturo254.opentune.ui.utils.ItemWrapper
+import com.arturo254.opentune.utils.LocalMediaScanner
+import kotlinx.coroutines.launch
+
+private val audioPermission =
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        Manifest.permission.READ_MEDIA_AUDIO
+    } else {
+        Manifest.permission.READ_EXTERNAL_STORAGE
+    }
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@Composable
+fun LocalSongsScreen(
+    navController: NavController,
+    onDeselect: () -> Unit,
+) {
+    val context = LocalContext.current
+    val database = LocalDatabase.current
+    val menuState = LocalMenuState.current
+    val haptic = LocalHapticFeedback.current
+    val playerConnection = LocalPlayerConnection.current ?: return
+    val isPlaying by playerConnection.isPlaying.collectAsState()
+    val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
+    val coroutineScope = rememberCoroutineScope()
+
+    var hasPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(context, audioPermission) ==
+                PackageManager.PERMISSION_GRANTED,
+        )
+    }
+    var isScanning by remember { mutableStateOf(false) }
+
+    fun scan() {
+        if (!hasPermission || isScanning) return
+        isScanning = true
+        coroutineScope.launch {
+            runCatching { LocalMediaScanner.scan(context, database) }
+            isScanning = false
+        }
+    }
+
+    val requestPermissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            hasPermission = granted
+            if (granted) scan()
+        }
+
+    LaunchedEffect(hasPermission) {
+        if (hasPermission) scan()
+    }
+
+    val songs by database.localSongs().collectAsState(initial = emptyList())
+
+    val wrappedSongs = songs.map { item -> ItemWrapper(item) }.toMutableList()
+    var selection by remember { mutableStateOf(false) }
+
+    val lazyListState = rememberLazyListState()
+    val pullRefreshState = rememberPullToRefreshState()
+
+    Box(
+        modifier = Modifier.fillMaxSize()
+            .pullToRefresh(
+                state = pullRefreshState,
+                isRefreshing = isScanning,
+                onRefresh = { scan() },
+            ),
+    ) {
+        LazyColumn(
+            state = lazyListState,
+            contentPadding = LocalPlayerAwareWindowInsets.current.asPaddingValues(),
+        ) {
+            item(key = "filter", contentType = CONTENT_TYPE_HEADER) {
+                Row {
+                    Spacer(Modifier.width(12.dp))
+                    FilterChip(
+                        label = { Text(stringResource(R.string.filter_on_device)) },
+                        selected = true,
+                        colors = FilterChipDefaults.filterChipColors(containerColor = MaterialTheme.colorScheme.surface),
+                        onClick = onDeselect,
+                        shape = RoundedCornerShape(16.dp),
+                        leadingIcon = {
+                            Icon(
+                                painter = painterResource(R.drawable.close),
+                                contentDescription = "",
+                            )
+                        },
+                    )
+                }
+            }
+
+            if (!hasPermission) {
+                item(key = "permission", contentType = CONTENT_TYPE_HEADER) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth().padding(24.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        Text(
+                            text = stringResource(R.string.local_music_permission_rationale),
+                            textAlign = TextAlign.Center,
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                        Button(onClick = { requestPermissionLauncher.launch(audioPermission) }) {
+                            Text(stringResource(R.string.grant_permission))
+                        }
+                    }
+                }
+            } else if (songs.isEmpty() && !isScanning) {
+                item(key = "empty", contentType = CONTENT_TYPE_HEADER) {
+                    Text(
+                        text = stringResource(R.string.no_local_music_found),
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.fillMaxWidth().padding(24.dp),
+                    )
+                }
+            } else {
+                item(key = "header", contentType = CONTENT_TYPE_HEADER) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(horizontal = 16.dp),
+                    ) {
+                        Spacer(Modifier.weight(1f))
+                        Text(
+                            text = pluralStringResource(R.plurals.n_song, songs.size, songs.size),
+                            style = MaterialTheme.typography.titleSmall,
+                            color = MaterialTheme.colorScheme.secondary,
+                        )
+                    }
+                }
+            }
+
+            itemsIndexed(
+                items = wrappedSongs,
+                key = { _, item -> item.item.song.id },
+                contentType = { _, _ -> CONTENT_TYPE_SONG },
+            ) { index, songWrapper ->
+                SongListItem(
+                    song = songWrapper.item,
+                    showInLibraryIcon = false,
+                    isActive = songWrapper.item.id == mediaMetadata?.id,
+                    isPlaying = isPlaying,
+                    trailingContent = {
+                        IconButton(
+                            onClick = {
+                                menuState.show {
+                                    SongMenu(
+                                        originalSong = songWrapper.item,
+                                        navController = navController,
+                                        onDismiss = menuState::dismiss,
+                                    )
+                                }
+                            },
+                        ) {
+                            Icon(
+                                painter = painterResource(R.drawable.more_vert),
+                                contentDescription = null,
+                            )
+                        }
+                    },
+                    isSelected = songWrapper.isSelected && selection,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .combinedClickable(
+                            onClick = {
+                                if (!selection) {
+                                    if (songWrapper.item.id == mediaMetadata?.id) {
+                                        playerConnection.player.togglePlayPause()
+                                    } else {
+                                        playerConnection.playQueue(
+                                            ListQueue(
+                                                title = context.getString(R.string.filter_on_device),
+                                                items = songs.map { it.toMediaItem() },
+                                                startIndex = index,
+                                            ),
+                                        )
+                                    }
+                                } else {
+                                    songWrapper.isSelected = !songWrapper.isSelected
+                                }
+                            },
+                            onLongClick = {
+                                haptic.performHapticFeedback(HapticFeedbackType.LongPress)
+                                if (!selection) selection = true
+                                wrappedSongs.forEach { it.isSelected = false }
+                                songWrapper.isSelected = true
+                            },
+                        )
+                        .animateItem(),
+                )
+            }
+        }
+
+        PullToRefreshDefaults.Indicator(
+            isRefreshing = isScanning,
+            state = pullRefreshState,
+            modifier = Modifier
+                .align(Alignment.TopCenter)
+                .padding(LocalPlayerAwareWindowInsets.current.asPaddingValues()),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/AppearanceSettings.kt
@@ -881,6 +881,7 @@ fun AppearanceSettings(
                     LibraryFilter.PLAYLISTS -> stringResource(R.string.playlists)
                     LibraryFilter.LIBRARY -> stringResource(R.string.filter_library)
                     LibraryFilter.SPOTIFY -> stringResource(R.string.spotify)
+                    LibraryFilter.ON_DEVICE -> stringResource(R.string.filter_on_device)
                 }
             },
             onValueSelected = onDefaultChipChange,

--- a/app/src/main/kotlin/com/arturo254/opentune/utils/LocalMediaScanner.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/utils/LocalMediaScanner.kt
@@ -1,0 +1,114 @@
+/*
+ * OpenTune Project Original (2026)
+ * Arturo254 (github.com/Arturo254)
+ * Licensed Under GPL-3.0 | see git history for contributors
+ */
+
+
+
+package com.arturo254.opentune.utils
+
+import android.content.ContentUris
+import android.content.Context
+import android.provider.MediaStore
+import com.arturo254.opentune.db.MusicDatabase
+import com.arturo254.opentune.db.entities.ArtistEntity
+import com.arturo254.opentune.db.entities.SongArtistMap
+import com.arturo254.opentune.db.entities.SongEntity
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+/** Stable id prefix for songs sourced from on-device MediaStore audio. */
+private const val LOCAL_SONG_ID_PREFIX = "LM"
+
+/**
+ * Scans the device's [MediaStore.Audio.Media] for playable audio files and upserts them into
+ * the app's [MusicDatabase] as regular [SongEntity] rows (isLocal = true), so they show up in
+ * the library/liked-songs UI alongside YouTube Music tracks.
+ */
+object LocalMediaScanner {
+
+    suspend fun scan(context: Context, database: MusicDatabase): Int = withContext(Dispatchers.IO) {
+        val projection = arrayOf(
+            MediaStore.Audio.Media._ID,
+            MediaStore.Audio.Media.TITLE,
+            MediaStore.Audio.Media.ARTIST,
+            MediaStore.Audio.Media.ALBUM,
+            MediaStore.Audio.Media.DURATION,
+            MediaStore.Audio.Media.DATE_MODIFIED,
+        )
+        val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
+
+        var count = 0
+        context.contentResolver.query(
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+            projection,
+            selection,
+            null,
+            null,
+        )?.use { cursor ->
+            val idCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
+            val titleCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TITLE)
+            val artistCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ARTIST)
+            val albumCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM)
+            val durationCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
+            val dateModifiedCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_MODIFIED)
+
+            while (cursor.moveToNext()) {
+                val mediaStoreId = cursor.getLong(idCol)
+                val contentUri = ContentUris.withAppendedId(
+                    MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+                    mediaStoreId,
+                )
+                val title = cursor.getString(titleCol) ?: continue
+                val artistName = cursor.getString(artistCol)?.takeUnless {
+                    it == "<unknown>" || it.isBlank()
+                } ?: "Unknown artist"
+                val albumName = cursor.getString(albumCol)
+                val durationMs = cursor.getLong(durationCol)
+                val dateModifiedSec = cursor.getLong(dateModifiedCol)
+
+                val songId = "$LOCAL_SONG_ID_PREFIX$mediaStoreId"
+                val now = LocalDateTime.now()
+                val dateModified = if (dateModifiedSec > 0) {
+                    LocalDateTime.ofInstant(Instant.ofEpochSecond(dateModifiedSec), ZoneId.systemDefault())
+                } else {
+                    null
+                }
+
+                database.withTransaction {
+                    val existing = song(songId).first()
+
+                    upsert(
+                        SongEntity(
+                            id = songId,
+                            title = title,
+                            duration = if (durationMs > 0) (durationMs / 1000).toInt() else -1,
+                            albumName = albumName,
+                            dateModified = dateModified,
+                            inLibrary = existing?.song?.inLibrary ?: now,
+                            liked = existing?.song?.liked ?: false,
+                            likedDate = existing?.song?.likedDate,
+                            isLocal = true,
+                            localPath = contentUri.toString(),
+                        ),
+                    )
+
+                    if (existing == null) {
+                        val artistId = artistByName(artistName)?.id
+                            ?: ArtistEntity.generateArtistId()
+                        insert(ArtistEntity(id = artistId, name = artistName))
+                        insert(SongArtistMap(songId = songId, artistId = artistId, position = 0))
+                    }
+                }
+
+                count++
+            }
+        }
+        count
+    }
+}

--- a/app/src/main/kotlin/com/arturo254/opentune/utils/LocalMediaScanner.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/utils/LocalMediaScanner.kt
@@ -10,20 +10,30 @@ package com.arturo254.opentune.utils
 
 import android.content.ContentUris
 import android.content.Context
+import android.media.MediaMetadataRetriever
+import android.net.Uri
 import android.provider.MediaStore
+import android.provider.OpenableColumns
 import com.arturo254.opentune.db.MusicDatabase
 import com.arturo254.opentune.db.entities.ArtistEntity
+import com.arturo254.opentune.db.entities.Song
 import com.arturo254.opentune.db.entities.SongArtistMap
 import com.arturo254.opentune.db.entities.SongEntity
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.io.FileOutputStream
+import java.security.MessageDigest
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
 
 /** Stable id prefix for songs sourced from on-device MediaStore audio. */
 private const val LOCAL_SONG_ID_PREFIX = "LM"
+
+/** Legacy but still functional MediaStore album-art URI, keyed by album id. */
+private val ALBUM_ART_URI = Uri.parse("content://media/external/audio/albumart")
 
 /**
  * Scans the device's [MediaStore.Audio.Media] for playable audio files and upserts them into
@@ -37,7 +47,10 @@ object LocalMediaScanner {
             MediaStore.Audio.Media._ID,
             MediaStore.Audio.Media.TITLE,
             MediaStore.Audio.Media.ARTIST,
+            MediaStore.Audio.Media.ALBUM_ARTIST,
             MediaStore.Audio.Media.ALBUM,
+            MediaStore.Audio.Media.ALBUM_ID,
+            MediaStore.Audio.Media.YEAR,
             MediaStore.Audio.Media.DURATION,
             MediaStore.Audio.Media.DATE_MODIFIED,
         )
@@ -54,7 +67,10 @@ object LocalMediaScanner {
             val idCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
             val titleCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.TITLE)
             val artistCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ARTIST)
+            val albumArtistCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ARTIST)
             val albumCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM)
+            val albumIdCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ID)
+            val yearCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.YEAR)
             val durationCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
             val dateModifiedCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_MODIFIED)
 
@@ -64,13 +80,29 @@ object LocalMediaScanner {
                     MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
                     mediaStoreId,
                 )
-                val title = cursor.getString(titleCol) ?: continue
-                val artistName = cursor.getString(artistCol)?.takeUnless {
-                    it == "<unknown>" || it.isBlank()
-                } ?: "Unknown artist"
-                val albumName = cursor.getString(albumCol)
+                val storeTitle = cursor.getString(titleCol)
+                val storeArtist = cursor.getString(artistCol)?.takeUnless { it.isUnknownTag() }
+                val storeAlbumArtist = cursor.getString(albumArtistCol)?.takeUnless { it.isUnknownTag() }
+                val albumName = cursor.getString(albumCol)?.takeUnless { it.isUnknownTag() }
+                val albumId = cursor.getLong(albumIdCol)
+                val storeYear = cursor.getInt(yearCol).takeIf { it > 0 }
+                val thumbnailUrl = ContentUris.withAppendedId(ALBUM_ART_URI, albumId).toString()
                 val durationMs = cursor.getLong(durationCol)
                 val dateModifiedSec = cursor.getLong(dateModifiedCol)
+
+                // MediaStore's tag indexing misses/mislabels artists on plenty of real-world
+                // files (untagged rips, unusual encoders); fall back to reading ID3/Vorbis/etc
+                // tags directly from the file only when we actually need to.
+                val needsTagFallback = storeTitle.isNullOrBlank() || storeArtist == null || storeYear == null
+                val tags = if (needsTagFallback) extractEmbeddedTags(context, contentUri) else null
+
+                val title = storeTitle?.takeUnless { it.isBlank() } ?: tags?.title ?: "Unknown title"
+                val artistName = storeArtist
+                    ?: storeAlbumArtist
+                    ?: tags?.artist
+                    ?: tags?.albumArtist
+                    ?: "Unknown artist"
+                val year = storeYear ?: tags?.year
 
                 val songId = "$LOCAL_SONG_ID_PREFIX$mediaStoreId"
                 val now = LocalDateTime.now()
@@ -80,35 +112,162 @@ object LocalMediaScanner {
                     null
                 }
 
-                database.withTransaction {
-                    val existing = song(songId).first()
-
-                    upsert(
-                        SongEntity(
-                            id = songId,
-                            title = title,
-                            duration = if (durationMs > 0) (durationMs / 1000).toInt() else -1,
-                            albumName = albumName,
-                            dateModified = dateModified,
-                            inLibrary = existing?.song?.inLibrary ?: now,
-                            liked = existing?.song?.liked ?: false,
-                            likedDate = existing?.song?.likedDate,
-                            isLocal = true,
-                            localPath = contentUri.toString(),
-                        ),
-                    )
-
-                    if (existing == null) {
-                        val artistId = artistByName(artistName)?.id
-                            ?: ArtistEntity.generateArtistId()
-                        insert(ArtistEntity(id = artistId, name = artistName))
-                        insert(SongArtistMap(songId = songId, artistId = artistId, position = 0))
-                    }
-                }
+                upsertLocalSong(
+                    database = database,
+                    songId = songId,
+                    title = title,
+                    artistName = artistName,
+                    durationSec = if (durationMs > 0) (durationMs / 1000).toInt() else -1,
+                    thumbnailUrl = thumbnailUrl,
+                    albumName = albumName,
+                    year = year,
+                    dateModified = dateModified,
+                    localPath = contentUri.toString(),
+                    now = now,
+                )
 
                 count++
             }
         }
         count
+    }
+
+    /**
+     * Scans a single, arbitrary content/file [uri] (e.g. from a file manager's "Open with") and
+     * upserts it into the library the same way [scan] does, so playback/notification/queue code
+     * — which is entirely DB-driven — works for it exactly like any other local song.
+     */
+    suspend fun scanUri(context: Context, database: MusicDatabase, uri: Uri): Song? = withContext(Dispatchers.IO) {
+        var displayName: String? = null
+        context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use { cursor ->
+            val nameCol = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+            if (nameCol >= 0 && cursor.moveToFirst()) {
+                displayName = cursor.getString(nameCol)
+            }
+        }
+
+        val tags = extractEmbeddedTags(context, uri)
+        val title = tags?.title
+            ?: displayName?.substringBeforeLast('.')?.takeUnless { it.isBlank() }
+            ?: "Unknown title"
+        val artistName = tags?.artist ?: tags?.albumArtist ?: "Unknown artist"
+        val thumbnailUrl = tags?.embeddedArt?.let { art -> saveEmbeddedArt(context, uri, art) }
+
+        val songId = "$LOCAL_SONG_ID_PREFIX${uri.toString().stableHash()}"
+        upsertLocalSong(
+            database = database,
+            songId = songId,
+            title = title,
+            artistName = artistName,
+            durationSec = tags?.durationMs?.takeIf { it > 0 }?.let { (it / 1000).toInt() } ?: -1,
+            thumbnailUrl = thumbnailUrl,
+            albumName = tags?.album,
+            year = tags?.year,
+            dateModified = null,
+            localPath = uri.toString(),
+            now = LocalDateTime.now(),
+        )
+
+        database.song(songId).first()
+    }
+
+    private suspend fun upsertLocalSong(
+        database: MusicDatabase,
+        songId: String,
+        title: String,
+        artistName: String,
+        durationSec: Int,
+        thumbnailUrl: String?,
+        albumName: String?,
+        year: Int?,
+        dateModified: LocalDateTime?,
+        localPath: String,
+        now: LocalDateTime,
+    ) {
+        database.withTransaction {
+            val existing = song(songId).first()
+
+            upsert(
+                SongEntity(
+                    id = songId,
+                    title = title,
+                    duration = durationSec,
+                    thumbnailUrl = thumbnailUrl ?: existing?.song?.thumbnailUrl,
+                    albumName = albumName,
+                    year = year,
+                    dateModified = dateModified,
+                    inLibrary = existing?.song?.inLibrary ?: now,
+                    liked = existing?.song?.liked ?: false,
+                    likedDate = existing?.song?.likedDate,
+                    isLocal = true,
+                    localPath = localPath,
+                ),
+            )
+
+            val currentMaps = songArtistMap(songId)
+            val currentArtistNames = currentMaps.mapNotNull { artist(it.artistId).first()?.artist?.name }
+            if (currentMaps.isEmpty() || currentArtistNames != listOf(artistName)) {
+                currentMaps.forEach { delete(it) }
+                val artistId = artistByName(artistName)?.id
+                    ?: ArtistEntity.generateArtistId()
+                insert(ArtistEntity(id = artistId, name = artistName))
+                insert(SongArtistMap(songId = songId, artistId = artistId, position = 0))
+            }
+        }
+    }
+
+    private fun String.stableHash(): String {
+        val bytes = MessageDigest.getInstance("MD5").digest(toByteArray())
+        return bytes.joinToString("") { "%02x".format(it) }.take(16)
+    }
+
+    private fun saveEmbeddedArt(context: Context, sourceUri: Uri, art: ByteArray): String? = runCatching {
+        val dir = File(context.filesDir, "local_album_art").apply { mkdirs() }
+        val file = File(dir, "${sourceUri.toString().stableHash()}.jpg")
+        FileOutputStream(file).use { it.write(art) }
+        Uri.fromFile(file).toString()
+    }.getOrNull()
+
+    private fun String.isUnknownTag() = isBlank() || equals("<unknown>", ignoreCase = true)
+
+    private data class EmbeddedTags(
+        val title: String?,
+        val artist: String?,
+        val albumArtist: String?,
+        val album: String?,
+        val year: Int?,
+        val durationMs: Long?,
+        val embeddedArt: ByteArray?,
+    )
+
+    /** Reads ID3/Vorbis/etc tags embedded in the file itself via [MediaMetadataRetriever]. */
+    private fun extractEmbeddedTags(context: Context, uri: Uri): EmbeddedTags? {
+        val retriever = MediaMetadataRetriever()
+        return runCatching {
+            retriever.setDataSource(context, uri)
+            EmbeddedTags(
+                title = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_TITLE)
+                    ?.takeUnless { it.isUnknownTag() },
+                artist = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ARTIST)
+                    ?.takeUnless { it.isUnknownTag() },
+                albumArtist = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUMARTIST)
+                    ?.takeUnless { it.isUnknownTag() }
+                    ?: retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_AUTHOR)
+                        ?.takeUnless { it.isUnknownTag() }
+                    ?: retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_COMPOSER)
+                        ?.takeUnless { it.isUnknownTag() },
+                album = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_ALBUM)
+                    ?.takeUnless { it.isUnknownTag() },
+                year = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_YEAR)
+                    ?.trim()
+                    ?.take(4)
+                    ?.toIntOrNull(),
+                durationMs = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)
+                    ?.toLongOrNull(),
+                embeddedArt = retriever.embeddedPicture,
+            )
+        }.also {
+            runCatching { retriever.release() }
+        }.getOrNull()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,12 @@
     <string name="filter_albums">Albums</string>
     <string name="filter_artists">Artists</string>
     <string name="filter_playlists">Playlists</string>
+    <string name="filter_on_device">On device</string>
+    <string name="local_music">Local music</string>
+    <string name="scan_local_music">Scan for local music</string>
+    <string name="local_music_permission_rationale">Allow access to your device\'s audio files to add them to your library and play them offline.</string>
+    <string name="grant_permission">Grant permission</string>
+    <string name="no_local_music_found">No local music found. Pull to refresh or add audio files to your device.</string>
     <string name="filter_community_playlists">Community playlists</string>
     <string name="filter_featured_playlists">Featured playlists</string>
     <string name="filter_bookmarked">Bookmarked</string>


### PR DESCRIPTION
## Summary

Adds support for playing audio files stored locally on the phone, alongside the existing YouTube Music streaming, reusing the app's existing song/library/player infrastructure rather than a parallel system.

- **DB**: restores `SongEntity.localPath` (deleted in an earlier migration) so local files can be tracked as regular library rows (`isLocal = true`).
- **Scanner**: `LocalMediaScanner` queries `MediaStore.Audio.Media` and upserts on-device tracks into the library. Falls back to reading embedded ID3/Vorbis tags via `MediaMetadataRetriever` (title/artist/album/year/artwork) when MediaStore's own index is missing or wrong, and re-resolves artist mapping on rescan.
- **Playback**: local songs resolve straight to their `content://` URI, bypassing the YouTube stream resolver; extended the ExoPlayer extractor set so local formats (mp3/flac/ogg/wav/etc.) beyond YouTube's mp4/webm actually play.
- **Favorites**: liking a local song uses the existing `localToggleLike()` path (no `YouTube.likeVideo` network call).
- **UI**: new "On Device" library tab with runtime permission request, pull-to-refresh rescan, and the standard song list/menu for playback, queueing, and likes.
- **Open with**: registers `audio/*` intent filters so local audio files can be opened directly from a file manager; the opened file is upserted into the library (same as the scanner) before playback so now-playing/notification/queue state — which is entirely DB-driven — populates correctly.
- **Menus**: hides YouTube-only actions (start radio, share, copy link, download, cache removal, external downloader, view artist/album, refetch, format details) across `SongMenu`, `PlayerMenu`, and the player's top action bar when the current song is local, since none of them apply to an on-device file.

## Test plan

- [x] `./gradlew :app:compileUniversalDebugKotlin` / `:app:assembleUniversalDebug` — builds clean
- [x] Manually installed on a physical device via `adb install`
- [x] Scanned on-device library, played local tracks (mp3), verified artwork/artist/duration show up
- [x] Liked/unliked a local track, confirmed no network call and it shows in Liked Songs
- [x] Opened a local audio file via a file manager's "Open with" → OpenTune, confirmed metadata/notification/queue populate
- [x] Verified YouTube streaming/menus are unaffected for non-local songs

🤖 Generated with [Claude Code](https://claude.com/claude-code)