### PR TITLE
fix: clean up stale local tracks and avoid rescanning on every tab open

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/library/LocalSongsScreen.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/library/LocalSongsScreen.kt
@@ -95,6 +95,7 @@ import com.arturo254.opentune.ui.component.SongListItem
 import com.arturo254.opentune.ui.menu.SongMenu
 import com.arturo254.opentune.utils.LocalMediaScanner
 import com.arturo254.opentune.utils.rememberPreference
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -150,11 +151,14 @@ fun LocalSongsScreen(
             if (granted) scan()
         }
 
-    LaunchedEffect(hasPermission) {
-        if (hasPermission) scan()
-    }
-
     val allSongs by database.localSongs().collectAsState(initial = emptyList())
+
+    // Only auto-scan once, on first entry, when permission is already granted but the
+    // library is still empty (e.g. first install). Re-opening this screen afterwards
+    // must not re-trigger a full MediaStore scan — use the rescan button for that.
+    LaunchedEffect(Unit) {
+        if (hasPermission && database.localSongs().first().isEmpty()) scan()
+    }
 
     val availableFolders by remember(allSongs) {
         derivedStateOf {

--- a/app/src/main/kotlin/com/arturo254/opentune/utils/LocalMediaScanner.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/utils/LocalMediaScanner.kt
@@ -56,6 +56,7 @@ object LocalMediaScanner {
         val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
 
         var count = 0
+        val seenSongIds = mutableSetOf<String>()
         context.contentResolver.query(
             MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
             projection,
@@ -106,6 +107,7 @@ object LocalMediaScanner {
                 val year = storeYear ?: tags?.year
 
                 val songId = "$LOCAL_SONG_ID_PREFIX$mediaStoreId"
+                seenSongIds += songId
                 val now = LocalDateTime.now()
                 val dateModified = if (dateModifiedSec > 0) {
                     LocalDateTime.ofInstant(Instant.ofEpochSecond(dateModifiedSec), ZoneId.systemDefault())
@@ -137,6 +139,16 @@ object LocalMediaScanner {
                 count++
             }
         }
+
+        // Drop library rows for MediaStore-sourced tracks whose file no longer exists
+        // (deleted/moved outside the app). Only touches ids scan() itself could have
+        // created — files added via scanUri() (e.g. "Open with") use a hash-based id
+        // and are left alone since they're outside the MediaStore index scan() covers.
+        database.localSongs().first()
+            .filter { it.song.id.removePrefix(LOCAL_SONG_ID_PREFIX).toLongOrNull() != null }
+            .filterNot { it.song.id in seenSongIds }
+            .forEach { database.delete(it.song) }
+
         count
     }
 


### PR DESCRIPTION
## Summary
- `LocalMediaScanner.scan()` now removes MediaStore-sourced library rows whose file no longer exists on disk (deleted/moved outside the app), instead of leaving dead entries forever.
- `LocalSongsScreen` no longer triggers a full rescan every time the On Device tab is opened; it now only auto-scans once on first entry when the library is empty, relying on the existing rescan control otherwise.

## Test plan
- Deleted a local file outside the app, pulled to refresh → track disappeared from the library.
- Reopened the On Device tab without refreshing → no rescan triggered.