### PR TITLE
fix: replace hardcoded Spanish UI strings with localized string resources

### DIFF
--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/AppleDeviceSelector.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/AppleDeviceSelector.kt
@@ -23,6 +23,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -141,7 +142,7 @@ fun DeviceSelectionBottomSheet(
                 Spacer(Modifier.height(16.dp))
 
                 Text(
-                    text = "Seleccionar dispositivo",
+                    text = stringResource(R.string.select_device),
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
                     color = textBackgroundColor,
@@ -153,13 +154,13 @@ fun DeviceSelectionBottomSheet(
                     val isActive = device == activeDevice
                     val deviceName = device.productName?.toString()
                         ?: when (device.type) {
-                            AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> "Altavoz"
-                            AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> "Auriculares con cable"
-                            AudioDeviceInfo.TYPE_WIRED_HEADSET -> "Headset con cable"
-                            AudioDeviceInfo.TYPE_BLUETOOTH_A2DP -> "Bluetooth"
-                            AudioDeviceInfo.TYPE_BLUETOOTH_SCO -> "Bluetooth SCO"
-                            AudioDeviceInfo.TYPE_BLE_HEADSET -> "BLE Headset"
-                            else -> "Dispositivo"
+                            AudioDeviceInfo.TYPE_BUILTIN_SPEAKER -> stringResource(R.string.device_speaker)
+                            AudioDeviceInfo.TYPE_WIRED_HEADPHONES -> stringResource(R.string.device_wired_headphones)
+                            AudioDeviceInfo.TYPE_WIRED_HEADSET -> stringResource(R.string.device_wired_headset)
+                            AudioDeviceInfo.TYPE_BLUETOOTH_A2DP -> stringResource(R.string.device_bluetooth)
+                            AudioDeviceInfo.TYPE_BLUETOOTH_SCO -> stringResource(R.string.device_bluetooth_sco)
+                            AudioDeviceInfo.TYPE_BLE_HEADSET -> stringResource(R.string.device_ble_headset)
+                            else -> stringResource(R.string.device)
                         }
 
                     val iconRes = when (device.type) {
@@ -256,7 +257,7 @@ fun DeviceSelectionBottomSheet(
                             .padding(12.dp)
                     ) {
                         Text(
-                            text = "Cerrar",
+                            text = stringResource(R.string.close),
                             style = MaterialTheme.typography.bodyLarge,
                             color = MaterialTheme.colorScheme.onSecondaryContainer
                         )

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/DragDrop.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/DragDrop.kt
@@ -290,7 +290,7 @@ fun DragDropLyricsProviderDialog(
                         modifier = Modifier.weight(1f),
                         shape = RoundedCornerShape(20.dp),
                     ) {
-                        Text("Cancelar")
+                        Text(stringResource(R.string.cancel))
                     }
                     Button(
                         onClick = {
@@ -306,7 +306,7 @@ fun DragDropLyricsProviderDialog(
                             modifier = Modifier.size(18.dp),
                         )
                         Spacer(Modifier.width(8.dp))
-                        Text("Guardar")
+                        Text(stringResource(R.string.save))
                     }
                 }
             }

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/LanguageSelector.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/LanguageSelector.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
@@ -101,7 +102,7 @@ fun LanguageSelectorBottomSheet(
     selectedCode: String,
     systemDefaultCode: String? = null,
     systemDefaultLabel: String = "",
-    searchPlaceholder: String = "Buscar idioma",
+    searchPlaceholder: String = stringResource(R.string.search_language),
     onDismiss: () -> Unit,
     onLanguageSelected: (String) -> Unit,
 ) {

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/LyricsCardConfig.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/LyricsCardConfig.kt
@@ -6,9 +6,12 @@
 
 package com.arturo254.opentune.ui.component
 
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.arturo254.opentune.R
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Layout styles — cada valor representa un diseño visual distinto para la tarjeta
@@ -21,27 +24,27 @@ enum class LyricsLayoutStyle(
 ) {
     GlassCard(
         displayName = "Glass Card",
-        description = "Panel de vidrio líquido",
+        description = "Liquid glass panel",
     ),
     Minimal(
         displayName = "Minimal",
-        description = "Limpio y sin distracciones",
+        description = "Clean and distraction-free",
     ),
     CoverFocused(
         displayName = "Cover Focus",
-        description = "Portada del álbum destacada",
+        description = "Featured album cover",
     ),
     Centered(
-        displayName = "Centrado",
-        description = "Letra como protagonista",
+        displayName = "Centered",
+        description = "Lyrics take center stage",
     ),
     BlurWash(
         displayName = "Blur Wash",
-        description = "Fondo ultra difuminado",
+        description = "Ultra-blurred background",
     ),
     StreamingModern(
         displayName = "Streaming",
-        description = "Estilo app de música moderna",
+        description = "Modern music app style",
     ),
 }
 
@@ -50,10 +53,21 @@ enum class LyricsLayoutStyle(
 // ─────────────────────────────────────────────────────────────────────────────
 
 enum class LyricsBackgroundType(val displayName: String) {
-    AlbumArt("Portada"),
-    SolidDark("Oscuro"),
-    SolidLight("Claro"),
-    Gradient("Degradado"),
+    AlbumArt("Cover art"),
+    SolidDark("Dark"),
+    SolidLight("Light"),
+    Gradient("Gradient"),
+}
+
+/** Localized label for [style], shown in the layout picker thumbnail. */
+@Composable
+fun LyricsLayoutStyle.localizedDisplayName(): String = when (this) {
+    LyricsLayoutStyle.GlassCard -> stringResource(R.string.lyrics_card_style_glass_card)
+    LyricsLayoutStyle.Minimal -> stringResource(R.string.lyrics_card_style_minimal)
+    LyricsLayoutStyle.CoverFocused -> stringResource(R.string.lyrics_card_style_cover_focused)
+    LyricsLayoutStyle.Centered -> stringResource(R.string.lyrics_card_style_centered)
+    LyricsLayoutStyle.BlurWash -> stringResource(R.string.lyrics_card_style_blur_wash)
+    LyricsLayoutStyle.StreamingModern -> stringResource(R.string.lyrics_card_style_streaming_modern)
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/component/LyricsShareCarouselSheet.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/component/LyricsShareCarouselSheet.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
@@ -117,7 +118,7 @@ fun LyricsShareCarouselSheet(
             Spacer(Modifier.height(22.dp))
 
             // ── Carrusel de layouts ───────────────────────────────────────
-            SheetSectionLabel("Diseño")
+            SheetSectionLabel(stringResource(R.string.lyrics_share_layout))
 
             Row(
                 modifier = Modifier
@@ -141,7 +142,7 @@ fun LyricsShareCarouselSheet(
             Spacer(Modifier.height(18.dp))
 
             // ── Selector de estilo de vidrio ──────────────────────────────
-            SheetSectionLabel("Estilo")
+            SheetSectionLabel(stringResource(R.string.lyrics_share_glass_style))
 
             Row(
                 modifier = Modifier
@@ -185,7 +186,7 @@ fun LyricsShareCarouselSheet(
                         modifier = Modifier.weight(1f),
                         shape    = RoundedCornerShape(14.dp),
                     ) {
-                        Text("Guardar")
+                        Text(stringResource(R.string.save))
                     }
                 } else {
                     OutlinedButton(
@@ -193,7 +194,7 @@ fun LyricsShareCarouselSheet(
                         modifier = Modifier.weight(1f),
                         shape    = RoundedCornerShape(14.dp),
                     ) {
-                        Text("Cancelar")
+                        Text(stringResource(R.string.cancel))
                     }
                 }
                 Button(
@@ -207,7 +208,7 @@ fun LyricsShareCarouselSheet(
                         modifier           = Modifier.size(18.dp),
                     )
                     Spacer(Modifier.width(8.dp))
-                    Text("Compartir")
+                    Text(stringResource(R.string.share))
                 }
             }
         }
@@ -332,7 +333,7 @@ private fun LayoutStyleThumbnail(
 
         Spacer(Modifier.height(5.dp))
         Text(
-            text       = style.displayName,
+            text       = style.localizedDisplayName(),
             style      = MaterialTheme.typography.labelSmall,
             color      = if (isSelected) MaterialTheme.colorScheme.primary
                          else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.65f),
@@ -419,7 +420,7 @@ private fun CustomizationPanel(
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
-                text       = "Personalización",
+                text       = stringResource(R.string.lyrics_share_customization),
                 style      = MaterialTheme.typography.titleSmall,
                 fontWeight = FontWeight.SemiBold,
             )
@@ -453,7 +454,7 @@ private fun CustomizationPanel(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
-                            "Tamaño de texto",
+                            stringResource(R.string.lyrics_share_text_size),
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.Medium,
                         )
@@ -475,7 +476,7 @@ private fun CustomizationPanel(
                 // ── Alineación del texto ──────────────────────────────────
                 Column {
                     Text(
-                        text       = "Alineación",
+                        text       = stringResource(R.string.lyrics_share_alignment),
                         style      = MaterialTheme.typography.bodyMedium,
                         fontWeight = FontWeight.Medium,
                         modifier   = Modifier.padding(bottom = 8.dp),
@@ -486,21 +487,21 @@ private fun CustomizationPanel(
                     ) {
                         AlignButton(
                             painter = painterResource(R.drawable.format_align_left),
-                            label = "Izquierda",
+                            label = stringResource(R.string.lyrics_share_align_left),
                             isSelected = config.textAlign == TextAlign.Start,
                             onClick = { onConfigChange(config.copy(textAlign = TextAlign.Start)) },
                         )
                         AlignButton(
                             painter = painterResource(R.drawable.format_align_center),
-                            label = "Izquierda",
-                            isSelected = config.textAlign == TextAlign.Start,
-                            onClick = { onConfigChange(config.copy(textAlign = TextAlign.Start)) },
+                            label = stringResource(R.string.lyrics_share_align_center),
+                            isSelected = config.textAlign == TextAlign.Center,
+                            onClick = { onConfigChange(config.copy(textAlign = TextAlign.Center)) },
                         )
                         AlignButton(
                             painter = painterResource(R.drawable.format_align_right),
-                            label = "Izquierda",
-                            isSelected = config.textAlign == TextAlign.Start,
-                            onClick = { onConfigChange(config.copy(textAlign = TextAlign.Start)) },
+                            label = stringResource(R.string.lyrics_share_align_right),
+                            isSelected = config.textAlign == TextAlign.End,
+                            onClick = { onConfigChange(config.copy(textAlign = TextAlign.End)) },
                         )
                     }
                 }
@@ -509,15 +510,15 @@ private fun CustomizationPanel(
 
                 // ── Visibilidad de elementos ──────────────────────────────
                 Text(
-                    text       = "Visibilidad",
+                    text       = stringResource(R.string.lyrics_share_visibility),
                     style      = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Medium,
                 )
                 Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                    ToggleRow("Mostrar título",    config.showTitle)   { onConfigChange(config.copy(showTitle   = it)) }
-                    ToggleRow("Mostrar artista",   config.showArtist)  { onConfigChange(config.copy(showArtist  = it)) }
-                    ToggleRow("Mostrar portada",   config.showCoverArt){ onConfigChange(config.copy(showCoverArt = it)) }
-                    ToggleRow("Mostrar OpenTune",  config.showBranding){ onConfigChange(config.copy(showBranding = it)) }
+                    ToggleRow(stringResource(R.string.lyrics_share_show_title),    config.showTitle)   { onConfigChange(config.copy(showTitle   = it)) }
+                    ToggleRow(stringResource(R.string.lyrics_share_show_artist),   config.showArtist)  { onConfigChange(config.copy(showArtist  = it)) }
+                    ToggleRow(stringResource(R.string.lyrics_share_show_cover),    config.showCoverArt){ onConfigChange(config.copy(showCoverArt = it)) }
+                    ToggleRow(stringResource(R.string.lyrics_share_show_branding), config.showBranding){ onConfigChange(config.copy(showBranding = it)) }
                 }
 
                 HorizontalDivider(color = MaterialTheme.colorScheme.outline.copy(alpha = 0.18f))
@@ -530,7 +531,7 @@ private fun CustomizationPanel(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
                         Text(
-                            "Espaciado",
+                            stringResource(R.string.lyrics_share_spacing),
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.Medium,
                         )

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/player/PlayerComponents.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/player/PlayerComponents.kt
@@ -83,6 +83,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.buildAnnotatedString
@@ -3137,10 +3138,7 @@ fun V8PlayerControlsContent(
                         .clip(RoundedCornerShape(4.dp))
                 )
                 Text(
-                    text = buildString {
-                        append("A continuación: ")
-                        append(nextUpMetadata.title)
-                    },
+                    text = stringResource(R.string.up_next_prefix, nextUpMetadata.title),
                     style = MaterialTheme.typography.labelSmall,
                     color = textBackgroundColor.copy(alpha = 0.55f),
                     maxLines = 1,

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/AlbumScreen.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/AlbumScreen.kt
@@ -338,12 +338,12 @@ private fun QualitySelectionDialog(
                     onDismiss()
                 }
             ) {
-                Text("Descargar")
+                Text(stringResource(R.string.download))
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text("Cancelar")
+                Text(stringResource(R.string.cancel))
             }
         }
     )
@@ -683,7 +683,7 @@ fun AlbumScreen(
                                     } else {
                                         Icon(
                                             painter = painterResource(R.drawable.download),
-                                            contentDescription = "Descargar carátula",
+                                            contentDescription = stringResource(R.string.download_cover_art),
                                             tint = Color.White.copy(alpha = 0.8f), // Ícono semi-transparente
                                             modifier = Modifier.size(24.dp) // Ícono más pequeño
                                         )

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/NewReleaseScreen.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/NewReleaseScreen.kt
@@ -606,7 +606,7 @@ private fun FeaturedCarousel(
                 }
             }
             Text(
-                text = "Lo más destacado",
+                text = stringResource(R.string.highlights),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/library/LibraryMixScreen.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/library/LibraryMixScreen.kt
@@ -828,7 +828,7 @@ private fun LibraryShortcutGrid(
 
             LibraryHeroFavoriteTile(
                 title = heroEntry.title,
-                iconRes = heroEntry.iconRes, badgeText = "Más reproducidos",
+                iconRes = heroEntry.iconRes, badgeText = stringResource(R.string.most_played),
 
                 accentColor = heroEntry.accentColor,
                 modifier = Modifier

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/library/LocalSongsScreen.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/library/LocalSongsScreen.kt
@@ -134,12 +134,17 @@ fun LocalSongsScreen(
     }
     var isScanning by remember { mutableStateOf(false) }
 
+    var availableFolders by remember { mutableStateOf(emptyList<String>()) }
+
     fun scan() {
         if (!hasPermission || isScanning) return
         isScanning = true
         coroutineScope.launch {
             runCatching {
-                LocalMediaScanner.scan(context, database)
+                LocalMediaScanner.scan(context, database, selectedFolders)
+            }
+            runCatching {
+                availableFolders = LocalMediaScanner.listAvailableFolders(context)
             }
             isScanning = false
         }
@@ -157,14 +162,12 @@ fun LocalSongsScreen(
     // library is still empty (e.g. first install). Re-opening this screen afterwards
     // must not re-trigger a full MediaStore scan — use the rescan button for that.
     LaunchedEffect(Unit) {
-        if (hasPermission && database.localSongs().first().isEmpty()) scan()
-    }
-
-    val availableFolders by remember(allSongs) {
-        derivedStateOf {
-            allSongs.mapNotNull { songItem ->
-                extractFolderNameFromLocalPath(songItem.song.localPath)
-            }.distinct().sorted()
+        if (hasPermission) {
+            if (database.localSongs().first().isEmpty()) {
+                scan()
+            } else {
+                runCatching { availableFolders = LocalMediaScanner.listAvailableFolders(context) }
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/library/LocalSongsScreen.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/library/LocalSongsScreen.kt
@@ -95,6 +95,7 @@ import com.arturo254.opentune.ui.component.SongListItem
 import com.arturo254.opentune.ui.menu.SongMenu
 import com.arturo254.opentune.utils.LocalMediaScanner
 import com.arturo254.opentune.utils.rememberPreference
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -150,11 +151,14 @@ fun LocalSongsScreen(
             if (granted) scan()
         }
 
-    LaunchedEffect(hasPermission) {
-        if (hasPermission) scan()
-    }
-
     val allSongs by database.localSongs().collectAsState(initial = emptyList())
+
+    // Only auto-scan once, on first entry, when permission is already granted but the
+    // library is still empty (e.g. first install). Re-opening this screen afterwards
+    // must not re-trigger a full MediaStore scan — use the rescan button for that.
+    LaunchedEffect(Unit) {
+        if (hasPermission && database.localSongs().first().isEmpty()) scan()
+    }
 
     val availableFolders by remember(allSongs) {
         derivedStateOf {

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/AppearanceSettings.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/AppearanceSettings.kt
@@ -895,7 +895,7 @@ fun AppearanceSettings(
 
         PreferenceEntry(
             title = { Text("Always On Display") },
-            description = "Estilos, formas y opciones de personalización",
+            description = stringResource(R.string.always_on_display_description),
             icon = { Icon(painterResource(R.drawable.dark_mode), null) },
             onClick = { navController.navigate("settings/appearance/always_on_display") }
         )

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/StorageSettings.kt
@@ -596,7 +596,7 @@ fun MD3ExpressiveCacheCard(
                                 onClick = { },
                                 label = {
                                     Text(
-                                        text = "⚠️ Casi lleno",
+                                        text = stringResource(R.string.storage_almost_full),
                                         style = MaterialTheme.typography.labelSmall,
                                         fontWeight = FontWeight.Medium
                                     )

--- a/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/UpdateScreen.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/ui/screens/settings/UpdateScreen.kt
@@ -173,6 +173,8 @@ fun UpdateScreen(
         }
     }
 
+    val unknownErrorText = stringResource(R.string.unknown_error_short)
+
     fun checkForUpdate() {
         if (updateCheckState == UpdateCheckState.Loading) return
         coroutineScope.launch {
@@ -188,7 +190,7 @@ fun UpdateScreen(
                     }
                 }
                 .onFailure { err ->
-                    updateCheckState = UpdateCheckState.Error(err.message ?: "Error desconocido")
+                    updateCheckState = UpdateCheckState.Error(err.message ?: unknownErrorText)
                 }
         }
     }
@@ -349,9 +351,9 @@ fun UpdateScreen(
                         ) {
                             val (msg, color) = when (val s = updateCheckState) {
                                 UpdateCheckState.UpToDate  ->
-                                    "Ya tienes la versión más reciente." to MaterialTheme.colorScheme.tertiary
+                                    stringResource(R.string.update_already_latest) to MaterialTheme.colorScheme.tertiary
                                 is UpdateCheckState.Error  ->
-                                    "Error: ${s.message}" to MaterialTheme.colorScheme.error
+                                    stringResource(R.string.update_error_prefix, s.message) to MaterialTheme.colorScheme.error
                                 else -> "" to MaterialTheme.colorScheme.onSurface
                             }
                             Spacer(Modifier.height(8.dp))
@@ -536,20 +538,20 @@ private fun UpdateCheckButton(
                     UpdateCheckState.Loading -> {
                         CircularProgressIndicator(Modifier.size(16.dp), strokeWidth = 2.dp, color = MaterialTheme.colorScheme.onPrimary)
                         Spacer(Modifier.width(8.dp))
-                        Text("Comprobando…")
+                        Text(stringResource(R.string.checking_for_update))
                     }
                     UpdateCheckState.UpToDate -> {
                         Icon(painterResource(R.drawable.done), null, Modifier.size(16.dp))
                         Spacer(Modifier.width(8.dp))
-                        Text("Al día")
+                        Text(stringResource(R.string.up_to_date))
                     }
                     is UpdateCheckState.UpdateAvailable -> {
                         Icon(painterResource(R.drawable.update), null, Modifier.size(16.dp))
                         Spacer(Modifier.width(8.dp))
-                        Text("Ver actualización (${s.info.versionName})")
+                        Text(stringResource(R.string.view_update, s.info.versionName))
                     }
                     is UpdateCheckState.Error -> {
-                        Text("Reintentar")
+                        Text(stringResource(R.string.retry))
                     }
                     else -> {
                         Icon(painterResource(R.drawable.update), null, Modifier.size(16.dp))
@@ -592,13 +594,13 @@ private fun UpdateDetailsBottomSheet(
                 .padding(bottom = 32.dp + LocalPlayerAwareWindowInsets.current.asPaddingValues().calculateBottomPadding())
         ) {
             Text(
-                text = "Nueva versión disponible",
+                text = stringResource(R.string.update_new_version_available),
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold
             )
             Spacer(Modifier.height(8.dp))
             Text(
-                text = "Versión ${info.versionName}",
+                text = stringResource(R.string.update_version_label, info.versionName),
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.primary
             )
@@ -616,7 +618,7 @@ private fun UpdateDetailsBottomSheet(
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Text(
-                            text = "Descargando actualización…",
+                            text = stringResource(R.string.update_downloading),
                             style = MaterialTheme.typography.bodyMedium,
                             fontWeight = FontWeight.SemiBold
                         )
@@ -636,7 +638,7 @@ private fun UpdateDetailsBottomSheet(
                     )
                     
                     Text(
-                        text = "La aplicación se reiniciará al finalizar la descarga.",
+                        text = stringResource(R.string.update_restart_notice),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                         textAlign = TextAlign.Center,

--- a/app/src/main/kotlin/com/arturo254/opentune/utils/LocalMediaScanner.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/utils/LocalMediaScanner.kt
@@ -30,8 +30,8 @@ import java.time.ZoneId
 /** Stable id prefix for songs sourced from on-device MediaStore audio. */
 private const val LOCAL_SONG_ID_PREFIX = "LM"
 
-/** Legacy but still functional MediaStore album-art URI, keyed by album id. */
-private val ALBUM_ART_URI = Uri.parse("content://media/external/audio/albumart")
+/** Sentinel meaning "no folder filter" in [SelectedLocalFoldersKey]-style preference sets. */
+private const val ALL_FOLDERS_SENTINEL = "Todas"
 
 /**
  * Scans the device's [MediaStore.Audio.Media] for playable audio files and upserts them into
@@ -40,7 +40,20 @@ private val ALBUM_ART_URI = Uri.parse("content://media/external/audio/albumart")
  */
 object LocalMediaScanner {
 
-    suspend fun scan(context: Context, database: MusicDatabase): Int = withContext(Dispatchers.IO) {
+    /**
+     * @param selectedFolders when non-empty (and not containing the "all folders" sentinel),
+     * restricts both the MediaStore query and the dead-row cleanup below to files whose parent
+     * folder name matches one of these — the same "last path segment" matching used by the
+     * folder picker UI. Tracks outside the selected folders are left untouched (neither
+     * re-verified nor deleted).
+     */
+    suspend fun scan(
+        context: Context,
+        database: MusicDatabase,
+        selectedFolders: Set<String> = emptySet(),
+    ): Int = withContext(Dispatchers.IO) {
+        val folderFilter = selectedFolders.takeUnless { it.isEmpty() || ALL_FOLDERS_SENTINEL in it }
+
         val projection = arrayOf(
             MediaStore.Audio.Media._ID,
             MediaStore.Audio.Media.TITLE,
@@ -53,7 +66,15 @@ object LocalMediaScanner {
             MediaStore.Audio.Media.DATE_MODIFIED,
             MediaStore.Audio.Media.DATA, // Ruta del archivo
         )
-        val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
+        val selection = buildString {
+            append("${MediaStore.Audio.Media.IS_MUSIC} != 0")
+            if (folderFilter != null) {
+                append(" AND (")
+                append(folderFilter.joinToString(" OR ") { "${MediaStore.Audio.Media.DATA} LIKE ?" })
+                append(")")
+            }
+        }
+        val selectionArgs = folderFilter?.map { "%/$it/%" }?.toTypedArray()
 
         var count = 0
         val seenSongIds = mutableSetOf<String>()
@@ -61,7 +82,7 @@ object LocalMediaScanner {
             MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
             projection,
             selection,
-            null,
+            selectionArgs,
             null,
         )?.use { cursor ->
             val idCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media._ID)
@@ -69,7 +90,6 @@ object LocalMediaScanner {
             val artistCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ARTIST)
             val albumArtistCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ARTIST)
             val albumCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM)
-            val albumIdCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.ALBUM_ID)
             val yearCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.YEAR)
             val durationCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DURATION)
             val dateModifiedCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATE_MODIFIED)
@@ -85,9 +105,7 @@ object LocalMediaScanner {
                 val storeArtist = cursor.getString(artistCol)?.takeUnless { it.isUnknownTag() }
                 val storeAlbumArtist = cursor.getString(albumArtistCol)?.takeUnless { it.isUnknownTag() }
                 val albumName = cursor.getString(albumCol)?.takeUnless { it.isUnknownTag() }
-                val albumId = cursor.getLong(albumIdCol)
                 val storeYear = cursor.getInt(yearCol).takeIf { it > 0 }
-                val thumbnailUrl = ContentUris.withAppendedId(ALBUM_ART_URI, albumId).toString()
                 val durationMs = cursor.getLong(durationCol)
                 val dateModifiedSec = cursor.getLong(dateModifiedCol)
                 val filePath = cursor.getString(dataCol)
@@ -105,6 +123,13 @@ object LocalMediaScanner {
                     ?: tags?.albumArtist
                     ?: "Unknown artist"
                 val year = storeYear ?: tags?.year
+
+                // Prefer embedded art when the tag fallback already ran (no extra IO cost);
+                // otherwise point at the track's own content URI and let
+                // LocalAudioThumbnailFetcher resolve it lazily at display time via
+                // ContentResolver.loadThumbnail(), rather than paying decode cost during scan.
+                val thumbnailUrl = tags?.embeddedArt?.let { art -> saveEmbeddedArt(context, contentUri, art) }
+                    ?: contentUri.toString()
 
                 val songId = "$LOCAL_SONG_ID_PREFIX$mediaStoreId"
                 seenSongIds += songId
@@ -142,68 +167,72 @@ object LocalMediaScanner {
 
         // Drop library rows for MediaStore-sourced tracks whose file no longer exists
         // (deleted/moved outside the app). Only touches ids scan() itself could have
-        // created — files added via scanUri() (e.g. "Open with") use a hash-based id
-        // and are left alone since they're outside the MediaStore index scan() covers.
+        // created — files added via scanUri() (e.g. "Open with") use a hash-based id and
+        // are cleaned up separately below. When a folder filter is active, only rows whose
+        // folder was actually scanned this pass are eligible: rows outside the current
+        // selection weren't looked at, so they can't be judged dead.
         database.localSongs().first()
             .filter { it.song.id.removePrefix(LOCAL_SONG_ID_PREFIX).toLongOrNull() != null }
+            .filter { folderFilter == null || folderNameOfLocalPath(it.song.localPath) in folderFilter }
             .filterNot { it.song.id in seenSongIds }
             .forEach { database.delete(it.song) }
+
+        cleanUpDeadScanUriSongs(context, database)
 
         count
     }
 
     /**
-     * Obtiene las carpetas disponibles que contienen música
-     * Usa el campo localPath de SongEntity
+     * Removes isLocal rows added via [scanUri] (non-numeric id suffix, so untouched by the
+     * MediaStore-driven cleanup above) whose backing file/content URI can no longer be opened.
      */
-    suspend fun getAvailableFolders(database: MusicDatabase): List<String> =
-        withContext(Dispatchers.IO) {
-            try {
-                // Obtener todas las canciones locales
-                val allSongs = database.localSongs().first()
+    private suspend fun cleanUpDeadScanUriSongs(context: Context, database: MusicDatabase) {
+        database.localSongs().first()
+            .filter { it.song.id.removePrefix(LOCAL_SONG_ID_PREFIX).toLongOrNull() == null }
+            .filter { songItem ->
+                val path = songItem.song.localPath ?: return@filter true
+                val uri = runCatching { Uri.parse(path) }.getOrNull() ?: return@filter true
+                val isAlive = runCatching {
+                    context.contentResolver.openInputStream(uri)?.use { true }
+                }.getOrNull() ?: false
+                !isAlive
+            }
+            .forEach { database.delete(it.song) }
+    }
 
-                // Extraer carpetas de las rutas de las canciones
-                val folders = allSongs.mapNotNull { songItem ->
-                    // Obtener el localPath directamente de SongEntity
-                    val localPath = songItem.song.localPath
-                    // Verificar que no sea null o vacío
-                    if (!localPath.isNullOrBlank()) {
-                        try {
-                            val uri = android.net.Uri.parse(localPath)
-                            val filePath = uri.path
-                            // Verificar que no sea null o vacío
-                            if (!filePath.isNullOrBlank()) {
-                                val file = File(filePath)
-                                val parent = file.parent
-                                // Verificar que no sea null o vacío
-                                if (!parent.isNullOrBlank()) {
-                                    // Extraer solo el nombre de la última carpeta para mostrar
-                                    val folderName = File(parent).name
-                                    if (folderName.isNotBlank()) {
-                                        folderName
-                                    } else {
-                                        parent
-                                    }
-                                } else {
-                                    null
-                                }
-                            } else {
-                                null
-                            }
-                        } catch (e: Exception) {
-                            null
-                        }
-                    } else {
-                        null
-                    }
-                }.distinct().sorted()
+    /** Same "last path segment" matching the folder-filter UI uses, applied to a stored [localPath]. */
+    private fun folderNameOfLocalPath(localPath: String?): String? {
+        if (localPath.isNullOrBlank()) return null
+        val filePath = runCatching { Uri.parse(localPath) }.getOrNull()?.path?.takeIf { it.isNotBlank() }
+            ?: return null
+        return runCatching { File(filePath).parentFile?.name }.getOrNull()
+    }
 
-                folders
-            } catch (e: Exception) {
-                // Si hay error, devolver lista vacía
-                emptyList()
+    /**
+     * Cheap, MediaStore-only folder discovery (no tag fallback, no DB writes) so the folder
+     * picker always lists every on-device folder, even ones a scoped [scan] hasn't touched yet.
+     */
+    suspend fun listAvailableFolders(context: Context): List<String> = withContext(Dispatchers.IO) {
+        val projection = arrayOf(MediaStore.Audio.Media.DATA)
+        val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
+        val folders = mutableSetOf<String>()
+
+        context.contentResolver.query(
+            MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
+            projection,
+            selection,
+            null,
+            null,
+        )?.use { cursor ->
+            val dataCol = cursor.getColumnIndexOrThrow(MediaStore.Audio.Media.DATA)
+            while (cursor.moveToNext()) {
+                val filePath = cursor.getString(dataCol) ?: continue
+                File(filePath).parentFile?.name?.takeIf { it.isNotBlank() }?.let { folders += it }
             }
         }
+
+        folders.sorted()
+    }
 
     /**
      * Scans a single, arbitrary content/file [uri] (e.g. from a file manager's "Open with") and

--- a/app/src/main/kotlin/com/arturo254/opentune/utils/LocalMediaScanner.kt
+++ b/app/src/main/kotlin/com/arturo254/opentune/utils/LocalMediaScanner.kt
@@ -56,6 +56,7 @@ object LocalMediaScanner {
         val selection = "${MediaStore.Audio.Media.IS_MUSIC} != 0"
 
         var count = 0
+        val seenSongIds = mutableSetOf<String>()
         context.contentResolver.query(
             MediaStore.Audio.Media.EXTERNAL_CONTENT_URI,
             projection,
@@ -106,6 +107,7 @@ object LocalMediaScanner {
                 val year = storeYear ?: tags?.year
 
                 val songId = "$LOCAL_SONG_ID_PREFIX$mediaStoreId"
+                seenSongIds += songId
                 val now = LocalDateTime.now()
                 val dateModified = if (dateModifiedSec > 0) {
                     LocalDateTime.ofInstant(Instant.ofEpochSecond(dateModifiedSec), ZoneId.systemDefault())
@@ -137,6 +139,16 @@ object LocalMediaScanner {
                 count++
             }
         }
+
+        // Drop library rows for MediaStore-sourced tracks whose file no longer exists
+        // (deleted/moved outside the app). Only touches ids scan() itself could have
+        // created — files added via scanUri() (e.g. "Open with") use a hash-based id
+        // and are left alone since they're outside the MediaStore index scan() covers.
+        database.localSongs().first()
+            .filter { it.song.id.removePrefix(LOCAL_SONG_ID_PREFIX).toLongOrNull() != null }
+            .filterNot { it.song.id in seenSongIds }
+            .forEach { database.delete(it.song) }
+
         count
     }
 

--- a/app/src/main/res/values/opentune_strings.xml
+++ b/app/src/main/res/values/opentune_strings.xml
@@ -490,4 +490,73 @@
     <string name="scanning_media">Scanning media</string>
     <string name="please_wait_scanning">Please wait while we scan your device for music</string>
     <string name="all_folders_visible">All folders are visible</string>
+
+    <!-- Lyrics share carousel sheet -->
+    <string name="lyrics_share_layout">Layout</string>
+    <string name="lyrics_share_glass_style">Style</string>
+    <string name="lyrics_share_customization">Customization</string>
+    <string name="lyrics_share_text_size">Text size</string>
+    <string name="lyrics_share_alignment">Alignment</string>
+    <string name="lyrics_share_align_left">Left</string>
+    <string name="lyrics_share_align_center">Center</string>
+    <string name="lyrics_share_align_right">Right</string>
+    <string name="lyrics_share_visibility">Visibility</string>
+    <string name="lyrics_share_show_title">Show title</string>
+    <string name="lyrics_share_show_artist">Show artist</string>
+    <string name="lyrics_share_show_cover">Show cover art</string>
+    <string name="lyrics_share_show_branding">Show OpenTune branding</string>
+    <string name="lyrics_share_spacing">Spacing</string>
+
+    <!-- Lyrics card layout styles -->
+    <string name="lyrics_card_style_glass_card">Glass Card</string>
+    <string name="lyrics_card_style_glass_card_desc">Liquid glass panel</string>
+    <string name="lyrics_card_style_minimal">Minimal</string>
+    <string name="lyrics_card_style_minimal_desc">Clean and distraction-free</string>
+    <string name="lyrics_card_style_cover_focused">Cover Focus</string>
+    <string name="lyrics_card_style_cover_focused_desc">Featured album cover</string>
+    <string name="lyrics_card_style_centered">Centered</string>
+    <string name="lyrics_card_style_centered_desc">Lyrics take center stage</string>
+    <string name="lyrics_card_style_blur_wash">Blur Wash</string>
+    <string name="lyrics_card_style_blur_wash_desc">Ultra-blurred background</string>
+    <string name="lyrics_card_style_streaming_modern">Streaming</string>
+    <string name="lyrics_card_style_streaming_modern_desc">Modern music app style</string>
+    <string name="lyrics_card_background_cover_art">Cover art</string>
+    <string name="lyrics_card_background_solid_dark">Dark</string>
+    <string name="lyrics_card_background_solid_light">Light</string>
+    <string name="lyrics_card_background_gradient">Gradient</string>
+
+    <!-- Misc device/language pickers -->
+    <string name="select_device">Select device</string>
+    <string name="device">Device</string>
+    <string name="device_speaker">Speaker</string>
+    <string name="device_wired_headphones">Wired headphones</string>
+    <string name="device_wired_headset">Wired headset</string>
+    <string name="device_bluetooth">Bluetooth</string>
+    <string name="device_bluetooth_sco">Bluetooth SCO</string>
+    <string name="device_ble_headset">BLE headset</string>
+    <string name="search_language">Search language</string>
+
+    <!-- Local music -->
+    <string name="on_device_shortcut">On Device</string>
+
+    <!-- Discovery / library -->
+    <string name="most_played">Most played</string>
+    <string name="highlights">Highlights</string>
+    <string name="featured">Featured</string>
+
+    <!-- Updater -->
+    <string name="unknown_error_short">Unknown error</string>
+    <string name="up_to_date">Up to date</string>
+    <string name="view_update">View update (%1$s)</string>
+    <string name="checking_for_update">Checking…</string>
+    <string name="download_cover_art">Download cover art</string>
+    <string name="always_on_display_description">Styles, shapes, and customization options</string>
+    <string name="up_next_prefix">Up next: %1$s</string>
+    <string name="storage_almost_full">⚠️ Almost full</string>
+    <string name="update_already_latest">You already have the latest version.</string>
+    <string name="update_new_version_available">New version available</string>
+    <string name="update_version_label">Version %1$s</string>
+    <string name="update_downloading">Downloading update…</string>
+    <string name="update_restart_notice">The app will restart once the download finishes.</string>
+    <string name="update_error_prefix">Error: %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
Several screens had Spanish text baked directly into the code instead of going through the string resource system (save/cancel/share buttons, device selector, language search placeholder, lyrics share sheet layout controls, update screen, storage warning, etc.), so they always showed Spanish regardless of the user's selected language and couldn't be translated via Crowdin/POEditor like everything else.

Also fixes a bug found while touching the lyrics share alignment buttons: the center and right align options both set `TextAlign.Start`, same as the left button.

## Test plan
- Built and manually checked the affected screens (lyrics share sheet, device selector, language picker, album screen, appearance settings, player, storage settings, update screen) on a device set to English.